### PR TITLE
Solution to issue #51:

### DIFF
--- a/src/main/java/com/devonfw/tools/solicitor/common/webcontent/CachingWebContentProviderBase.java
+++ b/src/main/java/com/devonfw/tools/solicitor/common/webcontent/CachingWebContentProviderBase.java
@@ -53,7 +53,12 @@ public abstract class CachingWebContentProviderBase implements WebContentProvide
      * @return the cache key
      */
     public String getKey(String url) {
-
+		/**
+    	 * Normalize URL to http
+    	 */
+    	if(url.startsWith("https")) {
+			url = url.replace("https", "http");
+		}
         String result = url.replaceAll("\\W", "_");
         return result;
     }


### PR DESCRIPTION
Avoid duplication of license texts in cache which only differ in protocol (http vs. https) #51

URL is normalized to "http" in CachingWebContentProviderBase.java