### PR TITLE
User guide hyperlink fix in readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ After building Solicitor via `mvn clean install` you might execute it with `java
 This will use some prepackaged internal sample data (taken from Devon4J) and sample rulesets and generates sample reports in the current directory. 
 
 ### User Guide
-See the [User Guide](documentation/master-solicitor.adoc) for further information about usage and configuration. The User Guide is also contained in the executable jar. Calling Solicitor via `java -jar target/solicitor.jar -eug` will store the User Guide in PDF format in the current working directory.
+See the [User Guide](documentation/master-solicitor.asciidoc) for further information about usage and configuration. The User Guide is also contained in the executable jar. Calling Solicitor via `java -jar target/solicitor.jar -eug` will store the User Guide in PDF format in the current working directory.
 
 ## Tutorials
 On the [devonfw Youtube Channel](https://www.youtube.com/channel/UCtb1p-24jus-QoXy49t9Xzg) you will find video tutorials on the usage of Solicitor:


### PR DESCRIPTION
This fixes the user guide hyperlink in solicitors readme.md for the new documentation setup