### PR TITLE
Fixing an issue in the yarn reader that lead to too big html license files…

### DIFF
--- a/src/main/java/com/devonfw/tools/solicitor/reader/yarn/YarnReader.java
+++ b/src/main/java/com/devonfw/tools/solicitor/reader/yarn/YarnReader.java
@@ -70,7 +70,7 @@ public class YarnReader extends AbstractReader implements Reader {
             String version = attributes.get(1);
             String repo = attributes.get(3);
             String license = attributes.get(2);
-            String licenseUrl = repo;
+            String licenseUrl = defaultGithubLicenseURL(repo);
             String homePage = "";
 
             // check whether VendorUrl is included in input file or not
@@ -96,6 +96,16 @@ public class YarnReader extends AbstractReader implements Reader {
 
     }
 
+    // helper method that defaults github-links (html) to a default license path
+    private String defaultGithubLicenseURL(String repo) {
+    	if (repo.contains("github.com") && !repo.contains("/raw/")) {
+            repo = repo.replace("git://", "https://");
+            repo = repo.replace("github.com", "raw.githubusercontent.com");
+            repo = repo.concat("/master/LICENSE");
+        }
+    	return repo;
+    }
+    
     // helper method that extracts information from the .json created by yarn
     // licenses into a correct form
     private String cutSourceJson(String sourceURL) {

--- a/src/test/java/com/devonfw/tools/solicitor/reader/yarn/YarnReaderTests.java
+++ b/src/test/java/com/devonfw/tools/solicitor/reader/yarn/YarnReaderTests.java
@@ -97,7 +97,7 @@ public class YarnReaderTests {
         boolean found = false;
         for (ApplicationComponent ap : lapc) {
             if (ap.getArtifactId().equals("test")
-                    && ap.getRawLicenses().get(0).getLicenseUrl().equals("https://github.com/mrtest/test")) {
+                    && ap.getRawLicenses().get(0).getLicenseUrl().equals("https://raw.githubusercontent.com/mrtest/test/master/LICENSE")) {
                 found = true;
                 break;
             }


### PR DESCRIPTION
… by defaulting github links with a license file path (e.g. raw.githubusercontent.com/x/y/master/LICENSE).

Description: 
In bigger projects, the yarn reader could cause memory issues because of too big license files. This was due to the fact that the yarn input files contain mostly html github.com links and solicitor would download them fully. 
This way, we default these html github links to a direct license file (if it exists). The html file would give no required information in any case.