### PR TITLE
CSV Reader Improvements according to Issue #7

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -80,7 +80,7 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-csv</artifactId>
-      <version>1.1</version>
+      <version>1.9.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.velocity</groupId>

--- a/core/src/main/java/com/devonfw/tools/solicitor/Solicitor.java
+++ b/core/src/main/java/com/devonfw/tools/solicitor/Solicitor.java
@@ -139,7 +139,7 @@ public class Solicitor {
             Reader reader = this.readerFactory.readerFor(readerSetup.getType());
             try {
                 reader.readInventory(readerSetup.getType(), readerSetup.getSource(), readerSetup.getApplication(),
-                        readerSetup.getUsagePattern(), readerSetup.getRepoType());
+                        readerSetup.getUsagePattern(), readerSetup.getRepoType(), readerSetup.getConfiguration());
             } catch (SolicitorRuntimeException sre) {
                 if (this.tolerateMissingInput && sre.getCause() instanceof FileNotFoundException) {
                     Application app = readerSetup.getApplication();

--- a/core/src/main/java/com/devonfw/tools/solicitor/SolicitorSetup.java
+++ b/core/src/main/java/com/devonfw/tools/solicitor/SolicitorSetup.java
@@ -34,6 +34,8 @@ public class SolicitorSetup {
         private UsagePattern usagePattern;
 
         private String repoType;
+        
+        private String configuration;
 
         /**
          * This method gets the field <code>application</code>.
@@ -84,6 +86,16 @@ public class SolicitorSetup {
 
             return this.repoType;
         }
+        
+        /**
+         * This method gets the field <code>configuration</code>.
+         *
+         * @return the field configuration
+         */
+        public String getConfiguration() {
+
+            return this.configuration;
+        }
 
         /**
          * This method sets the field <code>application</code>.
@@ -103,6 +115,16 @@ public class SolicitorSetup {
         public void setSource(String source) {
 
             this.source = source;
+        }
+        
+        /**
+         * This method sets the field <code>configuration</code>.
+         *
+         * @param configuration the new value of the field configuration
+         */
+        public void setConfiguration(String configuration) {
+
+            this.configuration = configuration;
         }
 
         /**

--- a/core/src/main/java/com/devonfw/tools/solicitor/SolicitorSetup.java
+++ b/core/src/main/java/com/devonfw/tools/solicitor/SolicitorSetup.java
@@ -6,6 +6,7 @@ package com.devonfw.tools.solicitor;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import org.springframework.stereotype.Component;
 
@@ -35,7 +36,7 @@ public class SolicitorSetup {
 
         private String repoType;
         
-        private String configuration;
+        private Map<String,String> configuration;
 
         /**
          * This method gets the field <code>application</code>.
@@ -92,7 +93,7 @@ public class SolicitorSetup {
          *
          * @return the field configuration
          */
-        public String getConfiguration() {
+        public Map<String,String> getConfiguration() {
 
             return this.configuration;
         }
@@ -122,7 +123,7 @@ public class SolicitorSetup {
          *
          * @param configuration the new value of the field configuration
          */
-        public void setConfiguration(String configuration) {
+        public void setConfiguration(Map<String,String> configuration) {
 
             this.configuration = configuration;
         }

--- a/core/src/main/java/com/devonfw/tools/solicitor/config/ConfigFactory.java
+++ b/core/src/main/java/com/devonfw/tools/solicitor/config/ConfigFactory.java
@@ -127,6 +127,7 @@ public class ConfigFactory {
                 rs.setSource(rc.getSource());
                 rs.setUsagePattern(rc.getUsagePattern());
                 rs.setRepoType(rc.getRepoType());
+                rs.setConfiguration(rc.getConfiguration());
                 rs = resolvePlaceholdersInReader(rs, placeHolderMap);
                 solicitorSetup.getReaderSetups().add(rs);
             }

--- a/core/src/main/java/com/devonfw/tools/solicitor/config/ReaderConfig.java
+++ b/core/src/main/java/com/devonfw/tools/solicitor/config/ReaderConfig.java
@@ -25,6 +25,9 @@ public class ReaderConfig {
 
     @JsonProperty
     private String repoType;
+    
+    @JsonProperty
+    private String configuration;
 
     /**
      * Standard constructor. Field {@link #repoType} will be initialized to
@@ -45,6 +48,16 @@ public class ReaderConfig {
         return this.repoType;
     }
 
+    /**
+     * This method gets the field <code>configuration</code>.
+     *
+     * @return the field configuration
+     */
+    public String getConfiguration() {
+
+        return this.configuration;
+    }
+    
     /**
      * This method gets the field <code>source</code>.
      *
@@ -83,6 +96,16 @@ public class ReaderConfig {
     public void setRepoType(String repoType) {
 
         this.repoType = repoType;
+    }
+    
+    /**
+     * This method sets the field <code>configuration</code>.
+     *
+     * @param configuration the new value of the field configuration
+     */
+    public void setConfiguration(String configuration) {
+
+        this.configuration = configuration;
     }
 
     /**

--- a/core/src/main/java/com/devonfw/tools/solicitor/config/ReaderConfig.java
+++ b/core/src/main/java/com/devonfw/tools/solicitor/config/ReaderConfig.java
@@ -4,6 +4,8 @@
 
 package com.devonfw.tools.solicitor.config;
 
+import java.util.Map;
+
 import com.devonfw.tools.solicitor.model.masterdata.UsagePattern;
 import com.devonfw.tools.solicitor.reader.Reader;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -27,7 +29,7 @@ public class ReaderConfig {
     private String repoType;
     
     @JsonProperty
-    private String configuration;
+    private Map<String,String> configuration;
 
     /**
      * Standard constructor. Field {@link #repoType} will be initialized to
@@ -53,7 +55,7 @@ public class ReaderConfig {
      *
      * @return the field configuration
      */
-    public String getConfiguration() {
+    public Map<String,String> getConfiguration() {
 
         return this.configuration;
     }
@@ -103,7 +105,7 @@ public class ReaderConfig {
      *
      * @param configuration the new value of the field configuration
      */
-    public void setConfiguration(String configuration) {
+    public void setConfiguration(Map<String,String> configuration) {
 
         this.configuration = configuration;
     }

--- a/core/src/main/java/com/devonfw/tools/solicitor/reader/Reader.java
+++ b/core/src/main/java/com/devonfw/tools/solicitor/reader/Reader.java
@@ -40,7 +40,7 @@ public interface Reader {
      * @param usagePattern the {@link UsagePattern} which applies for all read
      *        {@link ApplicationComponent}s
      * @param repoType the type of Repository to download the sources from
-     * @param configuration 
+     * @param configuration optional configuration settings for readers
      */
     public void readInventory(String type, String sourceUrl, Application application, UsagePattern usagePattern,
             String repoType, Map<String,String> configuration);

--- a/core/src/main/java/com/devonfw/tools/solicitor/reader/Reader.java
+++ b/core/src/main/java/com/devonfw/tools/solicitor/reader/Reader.java
@@ -38,7 +38,7 @@ public interface Reader {
      * @param usagePattern the {@link UsagePattern} which applies for all read
      *        {@link ApplicationComponent}s
      * @param repoType the type of Repository to download the sources from
-     * @param string 
+     * @param configuration 
      */
     public void readInventory(String type, String sourceUrl, Application application, UsagePattern usagePattern,
             String repoType, String configuration);

--- a/core/src/main/java/com/devonfw/tools/solicitor/reader/Reader.java
+++ b/core/src/main/java/com/devonfw/tools/solicitor/reader/Reader.java
@@ -4,6 +4,8 @@
 
 package com.devonfw.tools.solicitor.reader;
 
+import java.util.Map;
+
 import com.devonfw.tools.solicitor.model.inventory.ApplicationComponent;
 import com.devonfw.tools.solicitor.model.inventory.RawLicense;
 import com.devonfw.tools.solicitor.model.masterdata.Application;
@@ -41,6 +43,6 @@ public interface Reader {
      * @param configuration 
      */
     public void readInventory(String type, String sourceUrl, Application application, UsagePattern usagePattern,
-            String repoType, String configuration);
+            String repoType, Map<String,String> configuration);
 
 }

--- a/core/src/main/java/com/devonfw/tools/solicitor/reader/Reader.java
+++ b/core/src/main/java/com/devonfw/tools/solicitor/reader/Reader.java
@@ -38,8 +38,9 @@ public interface Reader {
      * @param usagePattern the {@link UsagePattern} which applies for all read
      *        {@link ApplicationComponent}s
      * @param repoType the type of Repository to download the sources from
+     * @param string 
      */
     public void readInventory(String type, String sourceUrl, Application application, UsagePattern usagePattern,
-            String repoType);
+            String repoType, String configuration);
 
 }

--- a/core/src/main/java/com/devonfw/tools/solicitor/reader/csv/CsvReader.java
+++ b/core/src/main/java/com/devonfw/tools/solicitor/reader/csv/CsvReader.java
@@ -96,15 +96,15 @@ public class CsvReader extends AbstractReader implements Reader {
 
                 //set strings from csv position defined by config
                 String groupId = "";
-                if(!configuration.get("groupId").isEmpty()) {
+                if(configuration.get("groupId") != null) {
                     groupId = record.get(Integer.parseInt(configuration.get("groupId")));
                 }
                 String license ="";
-                if(!configuration.get("license").isEmpty()) {
+                if(configuration.get("license") != null) {
                     license = record.get(Integer.parseInt(configuration.get("license")));
                 }
                 String licenseURL = "";
-                if(!configuration.get("licenseUrl").isEmpty()) {
+                if(configuration.get("licenseUrl") != null) {
                     licenseURL = record.get(Integer.parseInt(configuration.get("licenseUrl")));
                 }
                 String artifactId = record.get(Integer.parseInt(configuration.get("artifactId")));

--- a/core/src/main/java/com/devonfw/tools/solicitor/reader/csv/CsvReader.java
+++ b/core/src/main/java/com/devonfw/tools/solicitor/reader/csv/CsvReader.java
@@ -60,15 +60,14 @@ public class CsvReader extends AbstractReader implements Reader {
     /** {@inheritDoc} */
     @Override
     public void readInventory(String type, String sourceUrl, Application application, UsagePattern usagePattern,
-            String repoType, String configuration) {
+            String repoType, Map<String,String> configuration) {
     	
-    	Map<String,String> configMap = configurationToMap(configuration); 
-    	
+    	//Map<String,String> configMap = configurationToMap(configuration); 
+
     	System.out.println("this are the config parameters given in solicitor.cfg:");
+    	System.out.println(configuration.get("groupID"));
+    	System.out.println(configuration.get("artifactID"));
     	System.out.println(configuration);
-    	System.out.println(configMap.toString());
-    	System.out.println(configMap.get("groupID"));
-    	System.out.println(configMap.get("artifactID"));
     	System.out.println("\n");
 
     	String sourceEnding = sourceUrl.substring(sourceUrl.lastIndexOf("/") + 1);

--- a/core/src/main/java/com/devonfw/tools/solicitor/reader/csv/CsvReader.java
+++ b/core/src/main/java/com/devonfw/tools/solicitor/reader/csv/CsvReader.java
@@ -33,17 +33,17 @@ import com.devonfw.tools.solicitor.reader.Reader;
  * <li>artifactId</li>
  * <li>version</li>
  * </ul>
- * <p> Other optional (but recommended) parameters are:
+ * <p> 
+ * Other optional (but recommended) parameters are:
  * <ul>
  * <li>groupId</li>
  * <li>license</li>
  * <li>licenseURL</li>
- * <li>skipheader</li>
- * <li>quote</li>
- * <li>delimiter</li>
- * <li>format</li>
- * <li>charset</li>
  * </ul>
+ * Furthermore, settings concerning the csv format can be configured 
+ * according to the methods specified in:
+ * https://commons.apache.org/proper/commons-csv/apidocs/org/apache/commons/csv/CSVFormat.Builder.html
+ * </p>
  */
 @Component
 public class CsvReader extends AbstractReader implements Reader {
@@ -92,18 +92,102 @@ public class CsvReader extends AbstractReader implements Reader {
                 csvBuilder = CSVFormat.Builder.create();
             }      
             
+            if(configuration.get("allowDuplicateHeaderNames") != null) {
+	            if(configuration.get("allowDuplicateHeaderNames").equals("true")) {
+	            	csvBuilder.setAllowDuplicateHeaderNames(true);
+	            }else {
+	            	csvBuilder.setAllowDuplicateHeaderNames(false);
+	            }
+            }
+            
+            if(configuration.get("allowMissingColumnNames") != null) {
+	            if(configuration.get("allowMissingColumnNames").equals("true")) {
+	            	csvBuilder.setAllowMissingColumnNames(true);
+	            }else {
+	            	csvBuilder.setAllowMissingColumnNames(false);
+	            }
+            }
+            
+            if(configuration.get("autoFlush") != null) {
+	            if(configuration.get("autoFlush").equals("true")) {
+	            	csvBuilder.setAutoFlush(true);
+	            }else {
+	            	csvBuilder.setAutoFlush(false);
+	            }
+            }
+            
+            if(configuration.get("commentMarker") != null){
+                csvBuilder.setCommentMarker(configuration.get("commentMarker").toCharArray()[0]);
+            }
+
             if(configuration.get("delimiter") != null) {
             csvBuilder.setDelimiter(configuration.get("delimiter"));
             }
-            if(configuration.get("quote") != null) {
-            	char[] quoteChar = configuration.get("quote").toCharArray();
-            	csvBuilder.setQuote(quoteChar[0]);
+            
+            if(configuration.get("escape") != null){
+                csvBuilder.setEscape(configuration.get("escape").toCharArray()[0]);
             }
-            if(configuration.get("skipheader") != null) {
-	            if(configuration.get("skipheader").equals("yes")) {
-	            	csvBuilder.setHeader().setSkipHeaderRecord(true);
+            
+            if(configuration.get("ignoreEmptyLines") != null) {
+	            if(configuration.get("ignoreEmptyLines").equals("true")) {
+	            	csvBuilder.setIgnoreEmptyLines(true);
+	            }else {
+	            	csvBuilder.setIgnoreEmptyLines(false);
 	            }
             }
+            
+            if(configuration.get("ignoreHeaderCase") != null) {
+	            if(configuration.get("ignoreHeaderCase").equals("true")) {
+	            	csvBuilder.setIgnoreHeaderCase(true);
+	            }else {
+	            	csvBuilder.setIgnoreHeaderCase(false);
+	            }
+            }
+            
+            if(configuration.get("ignoreSurroundingSpaces") != null) {
+	            if(configuration.get("ignoreSurroundingSpaces").equals("true")) {
+	            	csvBuilder.setIgnoreSurroundingSpaces(true);
+	            }else {
+	            	csvBuilder.setIgnoreSurroundingSpaces(false);
+	            }
+            }
+            
+            if(configuration.get("nullString") != null) {
+                csvBuilder.setNullString(configuration.get("nullString"));
+                }
+
+            if(configuration.get("quote") != null) {
+            	csvBuilder.setQuote(configuration.get("quote").toCharArray()[0]);
+            }
+            
+            if(configuration.get("recordSeparator") != null) {
+                csvBuilder.setRecordSeparator(configuration.get("recordSeparator"));
+                }
+            
+            if(configuration.get("skipHeaderRecord") != null) {
+	            if(configuration.get("skipHeaderRecord").equals("true")) {
+	            	csvBuilder.setHeader().setSkipHeaderRecord(true);
+	            }else {
+	            	csvBuilder.setHeader().setSkipHeaderRecord(false);
+	            }
+            }
+            
+            if(configuration.get("trailingDelimiter") != null) {
+	            if(configuration.get("trailingDelimiter").equals("true")) {
+	            	csvBuilder.setTrailingDelimiter(true);
+	            }else {
+	            	csvBuilder.setTrailingDelimiter(false);
+	            }
+            }
+            
+            if(configuration.get("trim") != null) {
+	            if(configuration.get("trim").equals("true")) {
+	            	csvBuilder.setTrim(true);
+	            }else {
+	            	csvBuilder.setTrim(false);
+	            }
+            }
+
             csvFormat = csvBuilder.build(); 	    
 
             

--- a/core/src/main/java/com/devonfw/tools/solicitor/reader/csv/CsvReader.java
+++ b/core/src/main/java/com/devonfw/tools/solicitor/reader/csv/CsvReader.java
@@ -70,171 +70,209 @@ public class CsvReader extends AbstractReader implements Reader {
         InputStream is;
         try {
             is = inputStreamFactory.createInputStreamFor(sourceUrl);
-            java.io.Reader reader;
             
-            if(configuration.get("charset") != null) {
-                 reader = new InputStreamReader(is, configuration.get("charset"));
-	        }else {
-	             reader = new InputStreamReader(is);
-	        }   
+            
+            if (configuration != null) {
+            	//CSVReader setting with customizable configuration
+	            java.io.Reader reader;
+	            
+	            if(configuration.get("charset") != null) {
+	                 reader = new InputStreamReader(is, configuration.get("charset"));
+		        }else {
+		             reader = new InputStreamReader(is);
+		        }   
+	
+	            ApplicationComponent lastAppComponent = null;
+	            
+	            CSVFormat csvFormat;
+	            CSVFormat.Builder csvBuilder;
+	            
+	            //predefined format & overwrite values
+	            if(configuration.get("format") != null) {
+	            	csvFormat = CSVFormat.valueOf(configuration.get("format"));
+	                csvBuilder = CSVFormat.Builder.create(csvFormat);
+	            }else {
+	                csvBuilder = CSVFormat.Builder.create();
+	            }      
+	            
+	            if(configuration.get("allowDuplicateHeaderNames") != null) {
+		            if(configuration.get("allowDuplicateHeaderNames").equals("true")) {
+		            	csvBuilder.setAllowDuplicateHeaderNames(true);
+		            }else {
+		            	csvBuilder.setAllowDuplicateHeaderNames(false);
+		            }
+	            }
+	            
+	            if(configuration.get("allowMissingColumnNames") != null) {
+		            if(configuration.get("allowMissingColumnNames").equals("true")) {
+		            	csvBuilder.setAllowMissingColumnNames(true);
+		            }else {
+		            	csvBuilder.setAllowMissingColumnNames(false);
+		            }
+	            }
+	            
+	            if(configuration.get("autoFlush") != null) {
+		            if(configuration.get("autoFlush").equals("true")) {
+		            	csvBuilder.setAutoFlush(true);
+		            }else {
+		            	csvBuilder.setAutoFlush(false);
+		            }
+	            }
+	            
+	            if(configuration.get("commentMarker") != null){
+	                csvBuilder.setCommentMarker(configuration.get("commentMarker").toCharArray()[0]);
+	            }
+	
+	            if(configuration.get("delimiter") != null) {
+	            csvBuilder.setDelimiter(configuration.get("delimiter"));
+	            }
+	            
+	            if(configuration.get("escape") != null){
+	                csvBuilder.setEscape(configuration.get("escape").toCharArray()[0]);
+	            }
+	            
+	            if(configuration.get("ignoreEmptyLines") != null) {
+		            if(configuration.get("ignoreEmptyLines").equals("true")) {
+		            	csvBuilder.setIgnoreEmptyLines(true);
+		            }else {
+		            	csvBuilder.setIgnoreEmptyLines(false);
+		            }
+	            }
+	            
+	            if(configuration.get("ignoreHeaderCase") != null) {
+		            if(configuration.get("ignoreHeaderCase").equals("true")) {
+		            	csvBuilder.setIgnoreHeaderCase(true);
+		            }else {
+		            	csvBuilder.setIgnoreHeaderCase(false);
+		            }
+	            }
+	            
+	            if(configuration.get("ignoreSurroundingSpaces") != null) {
+		            if(configuration.get("ignoreSurroundingSpaces").equals("true")) {
+		            	csvBuilder.setIgnoreSurroundingSpaces(true);
+		            }else {
+		            	csvBuilder.setIgnoreSurroundingSpaces(false);
+		            }
+	            }
+	            
+	            if(configuration.get("nullString") != null) {
+	                csvBuilder.setNullString(configuration.get("nullString"));
+	                }
+	
+	            if(configuration.get("quote") != null) {
+	            	csvBuilder.setQuote(configuration.get("quote").toCharArray()[0]);
+	            }
+	            
+	            if(configuration.get("recordSeparator") != null) {
+	                csvBuilder.setRecordSeparator(configuration.get("recordSeparator"));
+	                }
+	            
+	            if(configuration.get("skipHeaderRecord") != null) {
+		            if(configuration.get("skipHeaderRecord").equals("true")) {
+		            	csvBuilder.setHeader().setSkipHeaderRecord(true);
+		            }else {
+		            	csvBuilder.setHeader().setSkipHeaderRecord(false);
+		            }
+	            }
+	            
+	            if(configuration.get("trailingDelimiter") != null) {
+		            if(configuration.get("trailingDelimiter").equals("true")) {
+		            	csvBuilder.setTrailingDelimiter(true);
+		            }else {
+		            	csvBuilder.setTrailingDelimiter(false);
+		            }
+	            }
+	            
+	            if(configuration.get("trim") != null) {
+		            if(configuration.get("trim").equals("true")) {
+		            	csvBuilder.setTrim(true);
+		            }else {
+		            	csvBuilder.setTrim(false);
+		            }
+	            }
+	
+	            csvFormat = csvBuilder.build(); 	    
+	
+	            
+	            for (CSVRecord record : csvFormat.parse(reader)) {
+	                ApplicationComponent appComponent = getModelFactory().newApplicationComponent();
+	
+	                String groupId = "";
+	                if(configuration.get("groupId") != null) {
+	                    groupId = record.get(Integer.parseInt(configuration.get("groupId")));
+	                }
+	                String license ="";
+	                if(configuration.get("license") != null) {
+	                    license = record.get(Integer.parseInt(configuration.get("license")));
+	                }
+	                String licenseURL = "";
+	                if(configuration.get("licenseUrl") != null) {
+	                    licenseURL = record.get(Integer.parseInt(configuration.get("licenseUrl")));
+	                }
+	                String artifactId = record.get(Integer.parseInt(configuration.get("artifactId")));
+	                String version = record.get(Integer.parseInt(configuration.get("version")));
+	                
+	                
+	                appComponent.setGroupId(groupId);
+	                appComponent.setArtifactId(artifactId);
+	                appComponent.setVersion(version);
+	                appComponent.setUsagePattern(usagePattern);
+	                appComponent.setRepoType(repoType);
 
-            ApplicationComponent lastAppComponent = null;
-            
-            //TODO add documentation in solicitor asciidoc
-            CSVFormat csvFormat;
-            CSVFormat.Builder csvBuilder;
-            
-            //predefined format + lets us overwrite values
-            if(configuration.get("format") != null) {
-            	csvFormat = CSVFormat.valueOf(configuration.get("format"));
-                csvBuilder = CSVFormat.Builder.create(csvFormat);
+	                // merge ApplicationComponentImpl with same key if they appear
+	                // on
+	                // subsequent lines (multilicensing)
+	                if (lastAppComponent != null && lastAppComponent.getGroupId().equals(appComponent.getGroupId())
+	                        && lastAppComponent.getArtifactId().equals(appComponent.getArtifactId())
+	                        && lastAppComponent.getVersion().equals(appComponent.getVersion())) {
+	                    // same applicationComponent as previous line ->
+	                    // append rawLicense to already existing
+	                    // ApplicationComponent
+	                } else {
+	                    // new ApplicationComponentImpl
+	                    appComponent.setApplication(application);
+	                    lastAppComponent = appComponent;
+	                    components++;
+	                }
+	                licenses++;
+	                
+	                addRawLicense(lastAppComponent, license, licenseURL, sourceUrl);
+	            }
             }else {
-                csvBuilder = CSVFormat.Builder.create();
-            }      
-            
-            if(configuration.get("allowDuplicateHeaderNames") != null) {
-	            if(configuration.get("allowDuplicateHeaderNames").equals("true")) {
-	            	csvBuilder.setAllowDuplicateHeaderNames(true);
-	            }else {
-	            	csvBuilder.setAllowDuplicateHeaderNames(false);
-	            }
-            }
-            
-            if(configuration.get("allowMissingColumnNames") != null) {
-	            if(configuration.get("allowMissingColumnNames").equals("true")) {
-	            	csvBuilder.setAllowMissingColumnNames(true);
-	            }else {
-	            	csvBuilder.setAllowMissingColumnNames(false);
-	            }
-            }
-            
-            if(configuration.get("autoFlush") != null) {
-	            if(configuration.get("autoFlush").equals("true")) {
-	            	csvBuilder.setAutoFlush(true);
-	            }else {
-	            	csvBuilder.setAutoFlush(false);
-	            }
-            }
-            
-            if(configuration.get("commentMarker") != null){
-                csvBuilder.setCommentMarker(configuration.get("commentMarker").toCharArray()[0]);
-            }
+            	//previous CSVReader setting without configuration
+            	is = inputStreamFactory.createInputStreamFor(sourceUrl);
 
-            if(configuration.get("delimiter") != null) {
-            csvBuilder.setDelimiter(configuration.get("delimiter"));
-            }
-            
-            if(configuration.get("escape") != null){
-                csvBuilder.setEscape(configuration.get("escape").toCharArray()[0]);
-            }
-            
-            if(configuration.get("ignoreEmptyLines") != null) {
-	            if(configuration.get("ignoreEmptyLines").equals("true")) {
-	            	csvBuilder.setIgnoreEmptyLines(true);
-	            }else {
-	            	csvBuilder.setIgnoreEmptyLines(false);
-	            }
-            }
-            
-            if(configuration.get("ignoreHeaderCase") != null) {
-	            if(configuration.get("ignoreHeaderCase").equals("true")) {
-	            	csvBuilder.setIgnoreHeaderCase(true);
-	            }else {
-	            	csvBuilder.setIgnoreHeaderCase(false);
-	            }
-            }
-            
-            if(configuration.get("ignoreSurroundingSpaces") != null) {
-	            if(configuration.get("ignoreSurroundingSpaces").equals("true")) {
-	            	csvBuilder.setIgnoreSurroundingSpaces(true);
-	            }else {
-	            	csvBuilder.setIgnoreSurroundingSpaces(false);
-	            }
-            }
-            
-            if(configuration.get("nullString") != null) {
-                csvBuilder.setNullString(configuration.get("nullString"));
-                }
-
-            if(configuration.get("quote") != null) {
-            	csvBuilder.setQuote(configuration.get("quote").toCharArray()[0]);
-            }
-            
-            if(configuration.get("recordSeparator") != null) {
-                csvBuilder.setRecordSeparator(configuration.get("recordSeparator"));
-                }
-            
-            if(configuration.get("skipHeaderRecord") != null) {
-	            if(configuration.get("skipHeaderRecord").equals("true")) {
-	            	csvBuilder.setHeader().setSkipHeaderRecord(true);
-	            }else {
-	            	csvBuilder.setHeader().setSkipHeaderRecord(false);
-	            }
-            }
-            
-            if(configuration.get("trailingDelimiter") != null) {
-	            if(configuration.get("trailingDelimiter").equals("true")) {
-	            	csvBuilder.setTrailingDelimiter(true);
-	            }else {
-	            	csvBuilder.setTrailingDelimiter(false);
-	            }
-            }
-            
-            if(configuration.get("trim") != null) {
-	            if(configuration.get("trim").equals("true")) {
-	            	csvBuilder.setTrim(true);
-	            }else {
-	            	csvBuilder.setTrim(false);
-	            }
-            }
-
-            csvFormat = csvBuilder.build(); 	    
-
-            
-            for (CSVRecord record : csvFormat.parse(reader)) {
-                ApplicationComponent appComponent = getModelFactory().newApplicationComponent();
-
-                //set strings from csv position defined by config
-                String groupId = "";
-                if(configuration.get("groupId") != null) {
-                    groupId = record.get(Integer.parseInt(configuration.get("groupId")));
-                }
-                String license ="";
-                if(configuration.get("license") != null) {
-                    license = record.get(Integer.parseInt(configuration.get("license")));
-                }
-                String licenseURL = "";
-                if(configuration.get("licenseUrl") != null) {
-                    licenseURL = record.get(Integer.parseInt(configuration.get("licenseUrl")));
-                }
-                String artifactId = record.get(Integer.parseInt(configuration.get("artifactId")));
-                String version = record.get(Integer.parseInt(configuration.get("version")));
+                java.io.Reader reader = new InputStreamReader(is);
+                ApplicationComponent lastAppComponent = null;
                 
-                
-                appComponent.setGroupId(groupId);
-                appComponent.setArtifactId(artifactId);
-                appComponent.setVersion(version);
-                appComponent.setUsagePattern(usagePattern);
-                appComponent.setRepoType(repoType);
-                // merge ApplicationComponentImpl with same key if they appear
-                // on
-                // subsequent lines (multilicensing)
-                if (lastAppComponent != null && lastAppComponent.getGroupId().equals(appComponent.getGroupId())
-                        && lastAppComponent.getArtifactId().equals(appComponent.getArtifactId())
-                        && lastAppComponent.getVersion().equals(appComponent.getVersion())) {
-                    // same applicationComponent as previous line ->
-                    // append rawLicense to already existing
-                    // ApplicationComponent
-                } else {
-                    // new ApplicationComponentImpl
-                    appComponent.setApplication(application);
-                    lastAppComponent = appComponent;
-                    components++;
+                for (CSVRecord record : CSVFormat.newFormat(';').parse(reader)) {
+                    ApplicationComponent appComponent = getModelFactory().newApplicationComponent();
+                    appComponent.setGroupId(record.get(0));
+                    appComponent.setArtifactId(record.get(1));
+                    appComponent.setVersion(record.get(2));
+                    appComponent.setUsagePattern(usagePattern);
+                    appComponent.setRepoType(repoType);
+                    // merge ApplicationComponentImpl with same key if they appear
+                    // on
+                    // subsequent lines (multilicensing)
+                    if (lastAppComponent != null && lastAppComponent.getGroupId().equals(appComponent.getGroupId())
+                            && lastAppComponent.getArtifactId().equals(appComponent.getArtifactId())
+                            && lastAppComponent.getVersion().equals(appComponent.getVersion())) {
+                        // same applicationComponent as previous line ->
+                        // append rawLicense to already existing
+                        // ApplicationComponent
+                    } else {
+                        // new ApplicationComponentImpl
+                        appComponent.setApplication(application);
+                        lastAppComponent = appComponent;
+                        components++;
+                    }
+                    licenses++;
+                    addRawLicense(lastAppComponent, record.get(3), record.get(4), sourceUrl);
                 }
-                licenses++;
-                
-                addRawLicense(lastAppComponent, license, licenseURL, sourceUrl);
             }
+            
+            
             doLogging(sourceUrl, application, components, licenses);
         } catch (IOException e1) {
             throw new SolicitorRuntimeException("Could not read CSV inventory source '" + sourceUrl + "'", e1);

--- a/core/src/main/java/com/devonfw/tools/solicitor/reader/csv/CsvReader.java
+++ b/core/src/main/java/com/devonfw/tools/solicitor/reader/csv/CsvReader.java
@@ -10,6 +10,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.util.Collections;
+import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 
@@ -23,6 +24,10 @@ import com.devonfw.tools.solicitor.model.masterdata.Application;
 import com.devonfw.tools.solicitor.model.masterdata.UsagePattern;
 import com.devonfw.tools.solicitor.reader.AbstractReader;
 import com.devonfw.tools.solicitor.reader.Reader;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
 
 /**
  * A {@link Reader} for files in CSV format.
@@ -57,8 +62,13 @@ public class CsvReader extends AbstractReader implements Reader {
     public void readInventory(String type, String sourceUrl, Application application, UsagePattern usagePattern,
             String repoType, String configuration) {
     	
-    	System.out.println("this is the config parameter given in solicitor.cfg:");
+    	Map<String,String> configMap = configurationToMap(configuration); 
+    	
+    	System.out.println("this are the config parameters given in solicitor.cfg:");
     	System.out.println(configuration);
+    	System.out.println(configMap.toString());
+    	System.out.println(configMap.get("groupID"));
+    	System.out.println(configMap.get("artifactID"));
     	System.out.println("\n");
 
     	String sourceEnding = sourceUrl.substring(sourceUrl.lastIndexOf("/") + 1);
@@ -140,5 +150,16 @@ public class CsvReader extends AbstractReader implements Reader {
         }
 
     }
-
+    
+    private Map<String,String> configurationToMap (String configuration) {
+    	ObjectMapper objectMapper = new ObjectMapper();
+    	TypeReference<Map<String, String>> typeRef  = new TypeReference<Map<String, String>>() {};
+    	try {
+			return objectMapper.readValue(configuration, typeRef);
+		} catch (IOException e) {
+			System.out.println("Something failed.");
+		}
+		return null;
+    }
+    
 }

--- a/core/src/main/java/com/devonfw/tools/solicitor/reader/csv/CsvReader.java
+++ b/core/src/main/java/com/devonfw/tools/solicitor/reader/csv/CsvReader.java
@@ -69,15 +69,6 @@ public class CsvReader extends AbstractReader implements Reader {
     public void readInventory(String type, String sourceUrl, Application application, UsagePattern usagePattern,
             String repoType, Map<String,String> configuration) {
     	
-    	//this is how to get out values of configuration file
-    	System.out.println("this are the config parameters given in solicitor.cfg:");
-    	System.out.println(configuration.get("groupId"));
-    	System.out.println(configuration.get("artifactId"));
-    	System.out.println(configuration);
-    	System.out.println("\n");
-
-
-
         int components = 0;
         int licenses = 0;
         InputStream is;
@@ -87,7 +78,6 @@ public class CsvReader extends AbstractReader implements Reader {
             java.io.Reader reader = new InputStreamReader(is);
             ApplicationComponent lastAppComponent = null;
             
-            //TODO apply newest common csv format with csvFormat Builder
             //TODO apply common csv formats like EXCEL as configuration parameter and disable rest if inputted
             //TODO add documentation in solicitor asciidoc
             CSVFormat.Builder csvBuilder = CSVFormat.Builder.create();
@@ -101,10 +91,6 @@ public class CsvReader extends AbstractReader implements Reader {
             }
             
             CSVFormat csvFormat = csvBuilder.build();
-            //if(configuration.get("skipheader").equals("yes")) {
-            	//csvFormat.withFirstRecordAsHeader().withIgnoreHeaderCase(); 
-            	//}
-
             for (CSVRecord record : csvFormat.parse(reader)) {
                 ApplicationComponent appComponent = getModelFactory().newApplicationComponent();
 

--- a/core/src/main/java/com/devonfw/tools/solicitor/reader/csv/CsvReader.java
+++ b/core/src/main/java/com/devonfw/tools/solicitor/reader/csv/CsvReader.java
@@ -32,19 +32,19 @@ import com.devonfw.tools.solicitor.reader.Reader;
  * <ul>
  * <li>artifactId</li>
  * <li>version</li>
- * </ul>
- * <p> 
+ * </ul> 
  * Other optional (but recommended) parameters are:
  * <ul>
+ * <li>charset</li>
  * <li>groupId</li>
  * <li>license</li>
- * <li>licenseURL</li>
+ * <li>licenseUrl</li>
  * </ul>
  * Furthermore, settings concerning the csv format can be configured 
  * according to the methods specified in:
  * https://commons.apache.org/proper/commons-csv/apidocs/org/apache/commons/csv/CSVFormat.Builder.html
- * </p>
  */
+
 @Component
 public class CsvReader extends AbstractReader implements Reader {
 

--- a/core/src/main/java/com/devonfw/tools/solicitor/reader/csv/CsvReader.java
+++ b/core/src/main/java/com/devonfw/tools/solicitor/reader/csv/CsvReader.java
@@ -65,11 +65,12 @@ public class CsvReader extends AbstractReader implements Reader {
     	try (FileInputStream file = new FileInputStream(configPath)) {
     	    props.load(file);
     	} catch (FileNotFoundException ex) {
-    	    //TODO
+            throw new SolicitorRuntimeException("Could not find config file '" + configPath + "'", ex);
     	} catch (IOException ex) {
-    	    //TODO
+            throw new SolicitorRuntimeException("Could not read config file '" + configPath + "'", ex);
     	}
-    	
+		System.out.println(props.getProperty("groupID")); //csvreader.config
+
         int components = 0;
         int licenses = 0;
         InputStream is;
@@ -89,7 +90,8 @@ public class CsvReader extends AbstractReader implements Reader {
             
             for (CSVRecord record : csvFormat.parse(reader)) {
                 ApplicationComponent appComponent = getModelFactory().newApplicationComponent();
-                
+        		System.out.println(props.getProperty("groupID")); //csvreader.config
+
                 //set strings from csv position defined by config
                 String groupId = "";
                 if(!props.getProperty("groupID").isEmpty()) {
@@ -101,7 +103,7 @@ public class CsvReader extends AbstractReader implements Reader {
                 }
                 String licenseURL = "";
                 if(!props.getProperty("licenseURL").isEmpty()) {
-                    licenseURL = record.get(Integer.parseInt(props.getProperty("license")));
+                    licenseURL = record.get(Integer.parseInt(props.getProperty("licenseURL")));
                 }
                 String artifactId = record.get(Integer.parseInt(props.getProperty("artifactID")));
                 String version = record.get(Integer.parseInt(props.getProperty("version")));

--- a/core/src/main/java/com/devonfw/tools/solicitor/reader/csv/CsvReader.java
+++ b/core/src/main/java/com/devonfw/tools/solicitor/reader/csv/CsvReader.java
@@ -55,12 +55,15 @@ public class CsvReader extends AbstractReader implements Reader {
     /** {@inheritDoc} */
     @Override
     public void readInventory(String type, String sourceUrl, Application application, UsagePattern usagePattern,
-            String repoType) {
+            String repoType, String configuration) {
     	
+    	System.out.println("this is the config parameter given in solicitor.cfg:");
+    	System.out.println(configuration);
+    	System.out.println("\n");
+
     	String sourceEnding = sourceUrl.substring(sourceUrl.lastIndexOf("/") + 1);
 		String configPath = sourceUrl.replace(sourceEnding, "csvreader.config");
 		configPath = configPath.replace("file:", "");
-		System.out.println(configPath); //csvreader.config
     	Properties props = new Properties();
     	try (FileInputStream file = new FileInputStream(configPath)) {
     	    props.load(file);
@@ -69,7 +72,6 @@ public class CsvReader extends AbstractReader implements Reader {
     	} catch (IOException ex) {
             throw new SolicitorRuntimeException("Could not read config file '" + configPath + "'", ex);
     	}
-		System.out.println(props.getProperty("groupID")); //csvreader.config
 
         int components = 0;
         int licenses = 0;
@@ -90,7 +92,6 @@ public class CsvReader extends AbstractReader implements Reader {
             
             for (CSVRecord record : csvFormat.parse(reader)) {
                 ApplicationComponent appComponent = getModelFactory().newApplicationComponent();
-        		System.out.println(props.getProperty("groupID")); //csvreader.config
 
                 //set strings from csv position defined by config
                 String groupId = "";

--- a/core/src/main/java/com/devonfw/tools/solicitor/reader/csv/CsvReader.java
+++ b/core/src/main/java/com/devonfw/tools/solicitor/reader/csv/CsvReader.java
@@ -79,12 +79,13 @@ public class CsvReader extends AbstractReader implements Reader {
             java.io.Reader reader = new InputStreamReader(is);
             ApplicationComponent lastAppComponent = null;
             CSVFormat csvFormat = CSVFormat.newFormat(props.getProperty("delimiter").charAt(0));
-            
             //checks if quote is set in config file
             if(!props.getProperty("quote").isEmpty()) {
                 csvFormat = csvFormat.withQuote((props.getProperty("quote")).charAt(0));
             }            
-           
+            if(props.getProperty("skipheader").equals("yes")) {
+            	csvFormat = csvFormat.withFirstRecordAsHeader().withSkipHeaderRecord();
+            }
             
             for (CSVRecord record : csvFormat.parse(reader)) {
                 ApplicationComponent appComponent = getModelFactory().newApplicationComponent();

--- a/core/src/main/java/com/devonfw/tools/solicitor/reader/csv/CsvReader.java
+++ b/core/src/main/java/com/devonfw/tools/solicitor/reader/csv/CsvReader.java
@@ -32,15 +32,21 @@ import com.fasterxml.jackson.databind.SerializationFeature;
 /**
  * A {@link Reader} for files in CSV format.
  * <p>
- * CSV files need to be separated with ";" and contain the following 5 columns
+ * CSV files need to be configured within the solicitor.cfg and 
+ * contain at least following parameters:
  * </p>
  * <ul>
- * <li>groupId</li>
- * <li>artifactId</li>
+ * <li>artifactID</li>
  * <li>version</li>
- * <li>license name</li>
- * <li>license URL</li>
  * </ul>
+ * <p> Other optional (but recommended) parameters are:
+ * <ul>
+ * <li>groupID
+ * <li>license</li>
+ * <li>licenseURL</li>
+ * <li>skipheader</li>
+ * <li>quote</li>
+ * <li>delimiter</li>
  */
 @Component
 public class CsvReader extends AbstractReader implements Reader {
@@ -62,14 +68,14 @@ public class CsvReader extends AbstractReader implements Reader {
     public void readInventory(String type, String sourceUrl, Application application, UsagePattern usagePattern,
             String repoType, Map<String,String> configuration) {
     	
-    	//Map<String,String> configMap = configurationToMap(configuration); 
-
+    	//this is how to get out values of configuration file
     	System.out.println("this are the config parameters given in solicitor.cfg:");
     	System.out.println(configuration.get("groupID"));
     	System.out.println(configuration.get("artifactID"));
     	System.out.println(configuration);
     	System.out.println("\n");
 
+    	//TODO replace config file logic with new configuration.get() methods
     	String sourceEnding = sourceUrl.substring(sourceUrl.lastIndexOf("/") + 1);
 		String configPath = sourceUrl.replace(sourceEnding, "csvreader.config");
 		configPath = configPath.replace("file:", "");
@@ -90,6 +96,10 @@ public class CsvReader extends AbstractReader implements Reader {
 
             java.io.Reader reader = new InputStreamReader(is);
             ApplicationComponent lastAppComponent = null;
+            
+            //TODO apply newest common csv format with csvFormat Builder
+            //TODO apply common csv formats like EXCEL as configuration parameter and disable rest if inputted
+            //TODO add documentation in solicitor asciidoc
             CSVFormat csvFormat = CSVFormat.newFormat(props.getProperty("delimiter").charAt(0));
             //checks if quote is set in config file
             if(!props.getProperty("quote").isEmpty()) {
@@ -98,6 +108,8 @@ public class CsvReader extends AbstractReader implements Reader {
             if(props.getProperty("skipheader").equals("yes")) {
             	csvFormat = csvFormat.withFirstRecordAsHeader().withSkipHeaderRecord();
             }
+            
+            
             
             for (CSVRecord record : csvFormat.parse(reader)) {
                 ApplicationComponent appComponent = getModelFactory().newApplicationComponent();
@@ -148,17 +160,6 @@ public class CsvReader extends AbstractReader implements Reader {
             throw new SolicitorRuntimeException("Could not read CSV inventory source '" + sourceUrl + "'", e1);
         }
 
-    }
-    
-    private Map<String,String> configurationToMap (String configuration) {
-    	ObjectMapper objectMapper = new ObjectMapper();
-    	TypeReference<Map<String, String>> typeRef  = new TypeReference<Map<String, String>>() {};
-    	try {
-			return objectMapper.readValue(configuration, typeRef);
-		} catch (IOException e) {
-			System.out.println("Something failed.");
-		}
-		return null;
     }
     
 }

--- a/core/src/main/java/com/devonfw/tools/solicitor/reader/csv/CsvReader.java
+++ b/core/src/main/java/com/devonfw/tools/solicitor/reader/csv/CsvReader.java
@@ -81,32 +81,32 @@ public class CsvReader extends AbstractReader implements Reader {
             ApplicationComponent lastAppComponent = null;
             
             //TODO add documentation in solicitor asciidoc
-            CSVFormat csvFormat = null;
+            CSVFormat csvFormat;
+            CSVFormat.Builder csvBuilder;
             
-            //Case that we have to set the format 
-            if(configuration.get("format") == null) {
-	            CSVFormat.Builder csvBuilder = CSVFormat.Builder.create();
-	            
-	            if(configuration.get("delimiter") != null) {
-	            csvBuilder.setDelimiter(configuration.get("delimiter"));
-	            }
-	            if(configuration.get("quote") != null) {
-	            	char[] quoteChar = configuration.get("quote").toCharArray();
-	            	csvBuilder.setQuote(quoteChar[0]);
-	            }
-	            if(configuration.get("skipheader") != null) {
-		            if(configuration.get("skipheader").equals("yes")) {
-		            	csvBuilder.setHeader().setSkipHeaderRecord(true);
-		            }
-	            }
-	            csvFormat = csvBuilder.build();
+            //predefined format + lets us overwrite values
+            if(configuration.get("format") != null) {
+            	csvFormat = CSVFormat.valueOf(configuration.get("format"));
+                csvBuilder = CSVFormat.Builder.create(csvFormat);
+            }else {
+                csvBuilder = CSVFormat.Builder.create();
+            }      
+            
+            if(configuration.get("delimiter") != null) {
+            csvBuilder.setDelimiter(configuration.get("delimiter"));
             }
-           //Use predefined formats
-	       else {
-	    	   csvFormat = CSVFormat.valueOf(configuration.get("format"));
-	    	   
-	       }
+            if(configuration.get("quote") != null) {
+            	char[] quoteChar = configuration.get("quote").toCharArray();
+            	csvBuilder.setQuote(quoteChar[0]);
+            }
+            if(configuration.get("skipheader") != null) {
+	            if(configuration.get("skipheader").equals("yes")) {
+	            	csvBuilder.setHeader().setSkipHeaderRecord(true);
+	            }
+            }
+            csvFormat = csvBuilder.build(); 	    
 
+            
             for (CSVRecord record : csvFormat.parse(reader)) {
                 ApplicationComponent appComponent = getModelFactory().newApplicationComponent();
 
@@ -125,7 +125,7 @@ public class CsvReader extends AbstractReader implements Reader {
                 }
                 String artifactId = record.get(Integer.parseInt(configuration.get("artifactId")));
                 String version = record.get(Integer.parseInt(configuration.get("version")));
-
+                
                 
                 appComponent.setGroupId(groupId);
                 appComponent.setArtifactId(artifactId);

--- a/core/src/main/java/com/devonfw/tools/solicitor/reader/csv/CsvReader.java
+++ b/core/src/main/java/com/devonfw/tools/solicitor/reader/csv/CsvReader.java
@@ -35,14 +35,17 @@ import com.devonfw.tools.solicitor.reader.Reader;
  * </ul> 
  * Other optional (but recommended) parameters are:
  * <ul>
- * <li>charset</li>
  * <li>groupId</li>
  * <li>license</li>
  * <li>licenseUrl</li>
  * </ul>
+ * It is also possible to overwrite the default machine charset with the "charset" option.
  * Furthermore, settings concerning the csv format can be configured 
  * according to the methods specified in:
  * https://commons.apache.org/proper/commons-csv/apidocs/org/apache/commons/csv/CSVFormat.Builder.html
+ * These options can also be used to overwrite an already existing predefined format 
+ * which can be set with "format" from:
+ * https://commons.apache.org/proper/commons-csv/apidocs/org/apache/commons/csv/CSVFormat.Predefined.html
  */
 
 @Component

--- a/core/src/main/java/com/devonfw/tools/solicitor/reader/csv/CsvReader.java
+++ b/core/src/main/java/com/devonfw/tools/solicitor/reader/csv/CsvReader.java
@@ -42,6 +42,7 @@ import com.devonfw.tools.solicitor.reader.Reader;
  * <li>quote</li>
  * <li>delimiter</li>
  * <li>format</li>
+ * <li>charset</li>
  * </ul>
  */
 @Component
@@ -69,8 +70,14 @@ public class CsvReader extends AbstractReader implements Reader {
         InputStream is;
         try {
             is = inputStreamFactory.createInputStreamFor(sourceUrl);
+            java.io.Reader reader;
+            
+            if(configuration.get("charset") != null) {
+                 reader = new InputStreamReader(is, configuration.get("charset"));
+	        }else {
+	             reader = new InputStreamReader(is);
+	        }   
 
-            java.io.Reader reader = new InputStreamReader(is);
             ApplicationComponent lastAppComponent = null;
             
             //TODO add documentation in solicitor asciidoc

--- a/core/src/main/java/com/devonfw/tools/solicitor/reader/csv/CsvReader.java
+++ b/core/src/main/java/com/devonfw/tools/solicitor/reader/csv/CsvReader.java
@@ -4,14 +4,11 @@
 
 package com.devonfw.tools.solicitor.reader.csv;
 
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.util.Collections;
 import java.util.Map;
-import java.util.Properties;
 import java.util.Set;
 
 import org.apache.commons.csv.CSVFormat;
@@ -24,10 +21,7 @@ import com.devonfw.tools.solicitor.model.masterdata.Application;
 import com.devonfw.tools.solicitor.model.masterdata.UsagePattern;
 import com.devonfw.tools.solicitor.reader.AbstractReader;
 import com.devonfw.tools.solicitor.reader.Reader;
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
+
 
 /**
  * A {@link Reader} for files in CSV format.
@@ -47,6 +41,7 @@ import com.fasterxml.jackson.databind.SerializationFeature;
  * <li>skipheader</li>
  * <li>quote</li>
  * <li>delimiter</li>
+ * <li>format</li>
  * </ul>
  */
 @Component
@@ -78,19 +73,33 @@ public class CsvReader extends AbstractReader implements Reader {
             java.io.Reader reader = new InputStreamReader(is);
             ApplicationComponent lastAppComponent = null;
             
-            //TODO apply common csv formats like EXCEL as configuration parameter and disable rest if inputted
             //TODO add documentation in solicitor asciidoc
-            CSVFormat.Builder csvBuilder = CSVFormat.Builder.create();
-            csvBuilder.setDelimiter(configuration.get("delimiter"));
-            if(configuration.get("skipheader").equals("yes")) {
-            	csvBuilder.setHeader().setSkipHeaderRecord(true);
-            }
-            if(!configuration.get("quote").isEmpty()) {
-            	char[] quoteChar = configuration.get("quote").toCharArray();
-            	csvBuilder.setQuote(quoteChar[0]);
-            }
+            CSVFormat csvFormat = null;
             
-            CSVFormat csvFormat = csvBuilder.build();
+            //Case that we have to set the format 
+            if(configuration.get("format") == null) {
+	            CSVFormat.Builder csvBuilder = CSVFormat.Builder.create();
+	            
+	            if(configuration.get("delimiter") != null) {
+	            csvBuilder.setDelimiter(configuration.get("delimiter"));
+	            }
+	            if(configuration.get("quote") != null) {
+	            	char[] quoteChar = configuration.get("quote").toCharArray();
+	            	csvBuilder.setQuote(quoteChar[0]);
+	            }
+	            if(configuration.get("skipheader") != null) {
+		            if(configuration.get("skipheader").equals("yes")) {
+		            	csvBuilder.setHeader().setSkipHeaderRecord(true);
+		            }
+	            }
+	            csvFormat = csvBuilder.build();
+            }
+           //Use predefined formats
+	       else {
+	    	   csvFormat = CSVFormat.valueOf(configuration.get("format"));
+	    	   
+	       }
+
             for (CSVRecord record : csvFormat.parse(reader)) {
                 ApplicationComponent appComponent = getModelFactory().newApplicationComponent();
 

--- a/core/src/main/java/com/devonfw/tools/solicitor/reader/gradle/GradleReader.java
+++ b/core/src/main/java/com/devonfw/tools/solicitor/reader/gradle/GradleReader.java
@@ -62,7 +62,7 @@ public class GradleReader extends AbstractReader implements Reader {
     /** {@inheritDoc} */
     @Override
     public void readInventory(String type, String sourceUrl, Application application, UsagePattern usagePattern,
-            String repoType) {
+            String repoType, String configuration) {
 
         this.deprecationChecker.check(false,
                 "Use of Reader of type 'gradle' is deprecated, use 'gradle2' instead. See https://github.com/devonfw/solicitor/issues/58");

--- a/core/src/main/java/com/devonfw/tools/solicitor/reader/gradle/GradleReader.java
+++ b/core/src/main/java/com/devonfw/tools/solicitor/reader/gradle/GradleReader.java
@@ -62,7 +62,7 @@ public class GradleReader extends AbstractReader implements Reader {
     /** {@inheritDoc} */
     @Override
     public void readInventory(String type, String sourceUrl, Application application, UsagePattern usagePattern,
-            String repoType, String configuration) {
+            String repoType, Map<String,String> configuration) {
 
         this.deprecationChecker.check(false,
                 "Use of Reader of type 'gradle' is deprecated, use 'gradle2' instead. See https://github.com/devonfw/solicitor/issues/58");

--- a/core/src/main/java/com/devonfw/tools/solicitor/reader/gradle/GradleReader2.java
+++ b/core/src/main/java/com/devonfw/tools/solicitor/reader/gradle/GradleReader2.java
@@ -48,7 +48,7 @@ public class GradleReader2 extends AbstractReader implements Reader {
     /** {@inheritDoc} */
     @Override
     public void readInventory(String type, String sourceUrl, Application application, UsagePattern usagePattern,
-            String repoType) {
+            String repoType, String configuration) {
 
         int components = 0;
         int licenses = 0;

--- a/core/src/main/java/com/devonfw/tools/solicitor/reader/gradle/GradleReader2.java
+++ b/core/src/main/java/com/devonfw/tools/solicitor/reader/gradle/GradleReader2.java
@@ -48,7 +48,7 @@ public class GradleReader2 extends AbstractReader implements Reader {
     /** {@inheritDoc} */
     @Override
     public void readInventory(String type, String sourceUrl, Application application, UsagePattern usagePattern,
-            String repoType, String configuration) {
+            String repoType, Map<String,String> configuration) {
 
         int components = 0;
         int licenses = 0;

--- a/core/src/main/java/com/devonfw/tools/solicitor/reader/maven/MavenReader.java
+++ b/core/src/main/java/com/devonfw/tools/solicitor/reader/maven/MavenReader.java
@@ -48,7 +48,7 @@ public class MavenReader extends AbstractReader implements Reader {
     /** {@inheritDoc} */
     @Override
     public void readInventory(String type, String sourceUrl, Application application, UsagePattern usagePattern,
-            String repoType) {
+            String repoType, String configuration) {
 
         int components = 0;
         int licenses = 0;

--- a/core/src/main/java/com/devonfw/tools/solicitor/reader/maven/MavenReader.java
+++ b/core/src/main/java/com/devonfw/tools/solicitor/reader/maven/MavenReader.java
@@ -7,6 +7,7 @@ package com.devonfw.tools.solicitor.reader.maven;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Collections;
+import java.util.Map;
 import java.util.Set;
 
 import javax.xml.bind.JAXBContext;
@@ -48,7 +49,7 @@ public class MavenReader extends AbstractReader implements Reader {
     /** {@inheritDoc} */
     @Override
     public void readInventory(String type, String sourceUrl, Application application, UsagePattern usagePattern,
-            String repoType, String configuration) {
+            String repoType, Map<String,String> configuration) {
 
         int components = 0;
         int licenses = 0;

--- a/core/src/main/java/com/devonfw/tools/solicitor/reader/npmlicensechecker/NpmLicenseCheckerReader.java
+++ b/core/src/main/java/com/devonfw/tools/solicitor/reader/npmlicensechecker/NpmLicenseCheckerReader.java
@@ -49,7 +49,7 @@ public class NpmLicenseCheckerReader extends AbstractReader implements Reader {
     @SuppressWarnings("rawtypes")
     @Override
     public void readInventory(String type, String sourceUrl, Application application, UsagePattern usagePattern,
-            String repoType) {
+            String repoType, String configuration) {
 
         int componentCount = 0;
         int licenseCount = 0;

--- a/core/src/main/java/com/devonfw/tools/solicitor/reader/npmlicensechecker/NpmLicenseCheckerReader.java
+++ b/core/src/main/java/com/devonfw/tools/solicitor/reader/npmlicensechecker/NpmLicenseCheckerReader.java
@@ -49,7 +49,7 @@ public class NpmLicenseCheckerReader extends AbstractReader implements Reader {
     @SuppressWarnings("rawtypes")
     @Override
     public void readInventory(String type, String sourceUrl, Application application, UsagePattern usagePattern,
-            String repoType, String configuration) {
+            String repoType, Map<String,String> configuration) {
 
         int componentCount = 0;
         int licenseCount = 0;

--- a/core/src/main/java/com/devonfw/tools/solicitor/reader/npmlicensecrawler/NpmLicenseCrawlerReader.java
+++ b/core/src/main/java/com/devonfw/tools/solicitor/reader/npmlicensecrawler/NpmLicenseCrawlerReader.java
@@ -60,7 +60,7 @@ public class NpmLicenseCrawlerReader extends AbstractReader implements Reader {
     /** {@inheritDoc} */
     @Override
     public void readInventory(String type, String sourceUrl, Application application, UsagePattern usagePattern,
-            String repoType) {
+            String repoType, String configuration) {
 
         if (SUPPORTED_TYPE_DEPRECATED.equals(type)) {
             deprecationChecker.check(true, "Use of type 'npm' is deprecated. Change type in config to '"

--- a/core/src/main/java/com/devonfw/tools/solicitor/reader/npmlicensecrawler/NpmLicenseCrawlerReader.java
+++ b/core/src/main/java/com/devonfw/tools/solicitor/reader/npmlicensecrawler/NpmLicenseCrawlerReader.java
@@ -9,6 +9,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 
 import org.apache.commons.csv.CSVFormat;
@@ -60,7 +61,7 @@ public class NpmLicenseCrawlerReader extends AbstractReader implements Reader {
     /** {@inheritDoc} */
     @Override
     public void readInventory(String type, String sourceUrl, Application application, UsagePattern usagePattern,
-            String repoType, String configuration) {
+            String repoType, Map<String,String> configuration) {
 
         if (SUPPORTED_TYPE_DEPRECATED.equals(type)) {
             deprecationChecker.check(true, "Use of type 'npm' is deprecated. Change type in config to '"

--- a/core/src/main/java/com/devonfw/tools/solicitor/reader/piplicenses/PipLicensesReader.java
+++ b/core/src/main/java/com/devonfw/tools/solicitor/reader/piplicenses/PipLicensesReader.java
@@ -44,7 +44,7 @@ public class PipLicensesReader extends AbstractReader implements Reader {
     @SuppressWarnings("rawtypes")
     @Override
     public void readInventory(String type, String sourceUrl, Application application, UsagePattern usagePattern,
-            String repoType) {
+            String repoType, String configuration) {
 
         int componentCount = 0;
         int licenseCount = 0;

--- a/core/src/main/java/com/devonfw/tools/solicitor/reader/piplicenses/PipLicensesReader.java
+++ b/core/src/main/java/com/devonfw/tools/solicitor/reader/piplicenses/PipLicensesReader.java
@@ -44,7 +44,7 @@ public class PipLicensesReader extends AbstractReader implements Reader {
     @SuppressWarnings("rawtypes")
     @Override
     public void readInventory(String type, String sourceUrl, Application application, UsagePattern usagePattern,
-            String repoType, String configuration) {
+            String repoType, Map<String,String> configuration) {
 
         int componentCount = 0;
         int licenseCount = 0;

--- a/core/src/main/java/com/devonfw/tools/solicitor/reader/yarn/YarnReader.java
+++ b/core/src/main/java/com/devonfw/tools/solicitor/reader/yarn/YarnReader.java
@@ -47,7 +47,7 @@ public class YarnReader extends AbstractReader implements Reader {
     @SuppressWarnings("rawtypes")
     @Override
     public void readInventory(String type, String sourceUrl, Application application, UsagePattern usagePattern,
-            String repoType) {
+            String repoType, String configuration) {
 
         String content = cutSourceJson(sourceUrl);
 

--- a/core/src/main/java/com/devonfw/tools/solicitor/reader/yarn/YarnReader.java
+++ b/core/src/main/java/com/devonfw/tools/solicitor/reader/yarn/YarnReader.java
@@ -10,6 +10,7 @@ import java.io.FileReader;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import org.springframework.stereotype.Component;
@@ -47,7 +48,7 @@ public class YarnReader extends AbstractReader implements Reader {
     @SuppressWarnings("rawtypes")
     @Override
     public void readInventory(String type, String sourceUrl, Application application, UsagePattern usagePattern,
-            String repoType, String configuration) {
+            String repoType, Map<String,String> configuration) {
 
         String content = cutSourceJson(sourceUrl);
 

--- a/core/src/test/java/com/devonfw/tools/solicitor/reader/csv/CsvReaderTests.java
+++ b/core/src/test/java/com/devonfw/tools/solicitor/reader/csv/CsvReaderTests.java
@@ -7,7 +7,9 @@ package com.devonfw.tools.solicitor.reader.csv;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.junit.Test;
 import org.slf4j.Logger;
@@ -27,6 +29,9 @@ public class CsvReaderTests {
 
     public CsvReaderTests() {
 
+    	Map<String,String> config = new HashMap<String,String>();
+    	config.put("groupID", "groupValue");
+    	
         ModelFactory modelFactory = new ModelFactoryImpl();
 
         this.application = modelFactory.newApplication("testApp", "0.0.0.TEST", "1.1.2111", "http://bla.com", "Java8");
@@ -34,7 +39,7 @@ public class CsvReaderTests {
         csvr.setModelFactory(modelFactory);
         csvr.setInputStreamFactory(new FileInputStreamFactory());
         csvr.readInventory("csv", "src/test/resources/csvlicenses.csv", this.application, UsagePattern.DYNAMIC_LINKING,
-                "maven","{\"groupID\" : \"test\" , \"artifactID\" : \"artifactTest\"}");
+                "maven",config);
 
     }
 

--- a/core/src/test/java/com/devonfw/tools/solicitor/reader/csv/CsvReaderTests.java
+++ b/core/src/test/java/com/devonfw/tools/solicitor/reader/csv/CsvReaderTests.java
@@ -29,8 +29,9 @@ public class CsvReaderTests {
 
     public CsvReaderTests() {
 
-    	Map<String,String> config = new HashMap<String,String>();
-    	config.put("groupID", "groupValue");
+    	//configuration settings
+    	Map<String,String> configuration = new HashMap<String,String>();
+    	configuration.put("groupID", "groupValue");
     	
         ModelFactory modelFactory = new ModelFactoryImpl();
 
@@ -39,7 +40,7 @@ public class CsvReaderTests {
         csvr.setModelFactory(modelFactory);
         csvr.setInputStreamFactory(new FileInputStreamFactory());
         csvr.readInventory("csv", "src/test/resources/csvlicenses.csv", this.application, UsagePattern.DYNAMIC_LINKING,
-                "maven",config);
+                "maven",configuration);
 
     }
 

--- a/core/src/test/java/com/devonfw/tools/solicitor/reader/csv/CsvReaderTests.java
+++ b/core/src/test/java/com/devonfw/tools/solicitor/reader/csv/CsvReaderTests.java
@@ -31,8 +31,15 @@ public class CsvReaderTests {
 
     	//configuration settings
     	Map<String,String> configuration = new HashMap<String,String>();
-    	configuration.put("groupID", "groupValue");
-    	
+    	configuration.put("groupId", "0");
+    	configuration.put("artifactId", "1");
+    	configuration.put("version", "2");
+    	configuration.put("license", "3");
+    	configuration.put("licenseUrl", "4");
+    	configuration.put("delimiter", ";");
+    	configuration.put("quote", "'");
+    	configuration.put("skipheader", "no");
+
         ModelFactory modelFactory = new ModelFactoryImpl();
 
         this.application = modelFactory.newApplication("testApp", "0.0.0.TEST", "1.1.2111", "http://bla.com", "Java8");

--- a/core/src/test/java/com/devonfw/tools/solicitor/reader/csv/CsvReaderTests.java
+++ b/core/src/test/java/com/devonfw/tools/solicitor/reader/csv/CsvReaderTests.java
@@ -34,7 +34,7 @@ public class CsvReaderTests {
         csvr.setModelFactory(modelFactory);
         csvr.setInputStreamFactory(new FileInputStreamFactory());
         csvr.readInventory("csv", "src/test/resources/csvlicenses.csv", this.application, UsagePattern.DYNAMIC_LINKING,
-                "maven","configuration");
+                "maven","{\"groupID\" : \"test\" , \"artifactID\" : \"artifactTest\"}");
 
     }
 

--- a/core/src/test/java/com/devonfw/tools/solicitor/reader/csv/CsvReaderTests.java
+++ b/core/src/test/java/com/devonfw/tools/solicitor/reader/csv/CsvReaderTests.java
@@ -34,7 +34,7 @@ public class CsvReaderTests {
         csvr.setModelFactory(modelFactory);
         csvr.setInputStreamFactory(new FileInputStreamFactory());
         csvr.readInventory("csv", "src/test/resources/csvlicenses.csv", this.application, UsagePattern.DYNAMIC_LINKING,
-                "maven");
+                "maven","configuration");
 
     }
 

--- a/core/src/test/java/com/devonfw/tools/solicitor/reader/csv/CsvReaderTests.java
+++ b/core/src/test/java/com/devonfw/tools/solicitor/reader/csv/CsvReaderTests.java
@@ -36,9 +36,21 @@ public class CsvReaderTests {
     	configuration.put("version", "2");
     	configuration.put("license", "3");
     	configuration.put("licenseUrl", "4");
+    	configuration.put("allowDuplicateHeaderNames", "false");
+    	configuration.put("allowMissingColumnNames", "false");
+    	configuration.put("autoFlush", "false");
+    	configuration.put("commentMarker", "#");
     	configuration.put("delimiter", ";");
+    	configuration.put("escape", "!");
+    	configuration.put("ignoreEmptyLines", "true");
+    	configuration.put("ignoreHeaderCase", "true");
+    	configuration.put("ignoreSurroundingSpaces", "true");
+    	configuration.put("nullString", "newNullString");
     	configuration.put("quote", "'");
-    	configuration.put("skipheader", "no");
+    	configuration.put("recordSeparator", "\n");
+    	configuration.put("skipHeaderRecord", "true");
+    	configuration.put("trailingDelimiter", "true");
+    	configuration.put("trim", "true");
 
         ModelFactory modelFactory = new ModelFactoryImpl();
 
@@ -58,7 +70,7 @@ public class CsvReaderTests {
         boolean found = false;
         for (ApplicationComponent ap : lapc) {
             if (ap.getGroupId().equals("org.antlr.runtime") && //
-                    ap.getArtifactId().equals("antlr") && //
+                    ap.getArtifactId().equals("antlr'") && //
                     ap.getVersion().equals("4.6.0")) {
                 found = true;
                 break;

--- a/core/src/test/java/com/devonfw/tools/solicitor/reader/csv/CsvReaderTests.java
+++ b/core/src/test/java/com/devonfw/tools/solicitor/reader/csv/CsvReaderTests.java
@@ -67,6 +67,7 @@ public class CsvReaderTests {
         List<ApplicationComponent> lapc = this.application.getApplicationComponents();
         boolean found = false;
         for (ApplicationComponent ap : lapc) {
+        	System.out.println(ap.getRawLicenses().get(0).getLicenseUrl());
             if (ap.getArtifactId().equals("xtend") && ap.getRawLicenses().get(0).getDeclaredLicense().equals("MIT")
                     && ap.getRawLicenses().get(0).getLicenseUrl().equals("https://spdx.org/licenses/MIT#licenseText")) {
                 found = true;

--- a/core/src/test/java/com/devonfw/tools/solicitor/reader/csv/CsvReaderTests.java
+++ b/core/src/test/java/com/devonfw/tools/solicitor/reader/csv/CsvReaderTests.java
@@ -92,7 +92,6 @@ public class CsvReaderTests {
         List<ApplicationComponent> lapc = this.application.getApplicationComponents();
         boolean found = false;
         for (ApplicationComponent ap : lapc) {
-        	System.out.println(ap.getRawLicenses().get(0).getLicenseUrl());
             if (ap.getArtifactId().equals("xtend") && ap.getRawLicenses().get(0).getDeclaredLicense().equals("MIT")
                     && ap.getRawLicenses().get(0).getLicenseUrl().equals("https://spdx.org/licenses/MIT#licenseText")) {
                 found = true;

--- a/core/src/test/java/com/devonfw/tools/solicitor/reader/gradle/GradleReader2Tests.java
+++ b/core/src/test/java/com/devonfw/tools/solicitor/reader/gradle/GradleReader2Tests.java
@@ -34,7 +34,7 @@ public class GradleReader2Tests {
         gr.setModelFactory(modelFactory);
         gr.setInputStreamFactory(new FileInputStreamFactory());
         gr.readInventory("gradle2", "src/test/resources/licenseReport.json", this.application,
-                UsagePattern.DYNAMIC_LINKING, "maven","config");
+                UsagePattern.DYNAMIC_LINKING, "maven",null);
 
     }
 

--- a/core/src/test/java/com/devonfw/tools/solicitor/reader/gradle/GradleReader2Tests.java
+++ b/core/src/test/java/com/devonfw/tools/solicitor/reader/gradle/GradleReader2Tests.java
@@ -34,7 +34,7 @@ public class GradleReader2Tests {
         gr.setModelFactory(modelFactory);
         gr.setInputStreamFactory(new FileInputStreamFactory());
         gr.readInventory("gradle2", "src/test/resources/licenseReport.json", this.application,
-                UsagePattern.DYNAMIC_LINKING, "maven");
+                UsagePattern.DYNAMIC_LINKING, "maven","config");
 
     }
 

--- a/core/src/test/java/com/devonfw/tools/solicitor/reader/gradle/GradleReaderTests.java
+++ b/core/src/test/java/com/devonfw/tools/solicitor/reader/gradle/GradleReaderTests.java
@@ -43,7 +43,7 @@ public class GradleReaderTests {
         gr.setModelFactory(modelFactory);
         gr.setInputStreamFactory(new FileInputStreamFactory());
         gr.readInventory("gradle", "src/test/resources/licenseReport.json", this.application,
-                UsagePattern.DYNAMIC_LINKING, "maven", "config");
+                UsagePattern.DYNAMIC_LINKING, "maven", null);
 
     }
 

--- a/core/src/test/java/com/devonfw/tools/solicitor/reader/gradle/GradleReaderTests.java
+++ b/core/src/test/java/com/devonfw/tools/solicitor/reader/gradle/GradleReaderTests.java
@@ -43,7 +43,7 @@ public class GradleReaderTests {
         gr.setModelFactory(modelFactory);
         gr.setInputStreamFactory(new FileInputStreamFactory());
         gr.readInventory("gradle", "src/test/resources/licenseReport.json", this.application,
-                UsagePattern.DYNAMIC_LINKING, "maven");
+                UsagePattern.DYNAMIC_LINKING, "maven", "config");
 
     }
 

--- a/core/src/test/java/com/devonfw/tools/solicitor/reader/maven/MavenReaderTests.java
+++ b/core/src/test/java/com/devonfw/tools/solicitor/reader/maven/MavenReaderTests.java
@@ -30,7 +30,7 @@ public class MavenReaderTests {
         mr.setModelFactory(modelFactory);
         mr.setInputStreamFactory(new FileInputStreamFactory());
         mr.readInventory("maven", "src/test/resources/licenses_sample.xml", application, UsagePattern.DYNAMIC_LINKING,
-                "maven");
+                "maven","config");
         LOG.info(application.toString());
         assertEquals(95, application.getApplicationComponents().size());
     }

--- a/core/src/test/java/com/devonfw/tools/solicitor/reader/maven/MavenReaderTests.java
+++ b/core/src/test/java/com/devonfw/tools/solicitor/reader/maven/MavenReaderTests.java
@@ -30,7 +30,7 @@ public class MavenReaderTests {
         mr.setModelFactory(modelFactory);
         mr.setInputStreamFactory(new FileInputStreamFactory());
         mr.readInventory("maven", "src/test/resources/licenses_sample.xml", application, UsagePattern.DYNAMIC_LINKING,
-                "maven","config");
+                "maven",null);
         LOG.info(application.toString());
         assertEquals(95, application.getApplicationComponents().size());
     }

--- a/core/src/test/java/com/devonfw/tools/solicitor/reader/npmlicensechecker/NpmLicenseCheckerReaderTests.java
+++ b/core/src/test/java/com/devonfw/tools/solicitor/reader/npmlicensechecker/NpmLicenseCheckerReaderTests.java
@@ -35,7 +35,7 @@ public class NpmLicenseCheckerReaderTests {
         gr.setModelFactory(modelFactory);
         gr.setInputStreamFactory(new FileInputStreamFactory());
         gr.readInventory("npm-license-checker", "src/test/resources/npmLicenseCheckerReport.json", this.application,
-                UsagePattern.DYNAMIC_LINKING, "npm", "config");
+                UsagePattern.DYNAMIC_LINKING, "npm", null);
 
     }
 

--- a/core/src/test/java/com/devonfw/tools/solicitor/reader/npmlicensechecker/NpmLicenseCheckerReaderTests.java
+++ b/core/src/test/java/com/devonfw/tools/solicitor/reader/npmlicensechecker/NpmLicenseCheckerReaderTests.java
@@ -35,7 +35,7 @@ public class NpmLicenseCheckerReaderTests {
         gr.setModelFactory(modelFactory);
         gr.setInputStreamFactory(new FileInputStreamFactory());
         gr.readInventory("npm-license-checker", "src/test/resources/npmLicenseCheckerReport.json", this.application,
-                UsagePattern.DYNAMIC_LINKING, "npm");
+                UsagePattern.DYNAMIC_LINKING, "npm", "config");
 
     }
 

--- a/core/src/test/java/com/devonfw/tools/solicitor/reader/npmlicensecrawler/NpmLicenseCrawlerReaderTests.java
+++ b/core/src/test/java/com/devonfw/tools/solicitor/reader/npmlicensecrawler/NpmLicenseCrawlerReaderTests.java
@@ -44,7 +44,7 @@ public class NpmLicenseCrawlerReaderTests {
         nr.setModelFactory(modelFactory);
         nr.setInputStreamFactory(new FileInputStreamFactory());
         nr.readInventory("npm", "src/test/resources/npmlicenses.csv", this.application, UsagePattern.DYNAMIC_LINKING,
-                "npm","config");
+                "npm",null);
     }
 
     @Test

--- a/core/src/test/java/com/devonfw/tools/solicitor/reader/npmlicensecrawler/NpmLicenseCrawlerReaderTests.java
+++ b/core/src/test/java/com/devonfw/tools/solicitor/reader/npmlicensecrawler/NpmLicenseCrawlerReaderTests.java
@@ -44,7 +44,7 @@ public class NpmLicenseCrawlerReaderTests {
         nr.setModelFactory(modelFactory);
         nr.setInputStreamFactory(new FileInputStreamFactory());
         nr.readInventory("npm", "src/test/resources/npmlicenses.csv", this.application, UsagePattern.DYNAMIC_LINKING,
-                "npm");
+                "npm","config");
     }
 
     @Test

--- a/core/src/test/java/com/devonfw/tools/solicitor/reader/piplicenses/PipReaderTests.java
+++ b/core/src/test/java/com/devonfw/tools/solicitor/reader/piplicenses/PipReaderTests.java
@@ -34,7 +34,7 @@ public class PipReaderTests {
         pr.setModelFactory(modelFactory);
         pr.setInputStreamFactory(new FileInputStreamFactory());
         pr.readInventory("pip", "src/test/resources/pipReport.json", this.application, UsagePattern.DYNAMIC_LINKING,
-                "pip", "config");
+                "pip", null);
 
     }
 

--- a/core/src/test/java/com/devonfw/tools/solicitor/reader/piplicenses/PipReaderTests.java
+++ b/core/src/test/java/com/devonfw/tools/solicitor/reader/piplicenses/PipReaderTests.java
@@ -34,7 +34,7 @@ public class PipReaderTests {
         pr.setModelFactory(modelFactory);
         pr.setInputStreamFactory(new FileInputStreamFactory());
         pr.readInventory("pip", "src/test/resources/pipReport.json", this.application, UsagePattern.DYNAMIC_LINKING,
-                "pip");
+                "pip", "config");
 
     }
 

--- a/core/src/test/java/com/devonfw/tools/solicitor/reader/yarn/YarnReaderTests.java
+++ b/core/src/test/java/com/devonfw/tools/solicitor/reader/yarn/YarnReaderTests.java
@@ -35,7 +35,7 @@ public class YarnReaderTests {
         yr.setModelFactory(modelFactory);
         yr.setInputStreamFactory(new FileInputStreamFactory());
         yr.readInventory("yarn", "src/test/resources/yarnReport.json", this.application, UsagePattern.DYNAMIC_LINKING,
-                "yarn");
+                "yarn","config");
 
     }
 

--- a/core/src/test/java/com/devonfw/tools/solicitor/reader/yarn/YarnReaderTests.java
+++ b/core/src/test/java/com/devonfw/tools/solicitor/reader/yarn/YarnReaderTests.java
@@ -35,7 +35,7 @@ public class YarnReaderTests {
         yr.setModelFactory(modelFactory);
         yr.setInputStreamFactory(new FileInputStreamFactory());
         yr.readInventory("yarn", "src/test/resources/yarnReport.json", this.application, UsagePattern.DYNAMIC_LINKING,
-                "yarn","config");
+                "yarn",null);
 
     }
 

--- a/core/src/test/resources/csvlicenses.csv
+++ b/core/src/test/resources/csvlicenses.csv
@@ -1,5 +1,9 @@
-﻿org.eclipse;albireo;0.0.3;Eclipse Public License - v 1.0;https://www.eclipse.org/legal/epl-v10.html
-org.antlr.runtime;antlr;4.6.0;BSD;https://www.antlr.org/license.html
+﻿groupId;artifactId;version;license;licenseUrl
+org.eclipse;albireo;0.0.3;Eclipse Public License - v 1.0;https://www.eclipse.org/legal/epl-v10.html
+org.antlr.runtime;'antlr!'';4.6.0;BSD;https://www.antlr.org/license.html
 org.eclipse.equinox.p2;Equinox p2 Provisioning for IDEs;2.3.2;Eclipse Public License - v 1.0;http://www.eclipse.org/legal/epl-v10.html
 org.springframework;spring;5.0.6;Apache 2;https://www.apache.org/licenses/LICENSE-2.0
+
 org.eclipse.xtend;xtend;2.2.0;MIT;https://spdx.org/licenses/MIT#licenseText
+
+#this is a comment

--- a/documentation/files/csvlicenses.csv
+++ b/documentation/files/csvlicenses.csv
@@ -1,8 +1,5 @@
-﻿groupId;ArtifactId;version;license;licenseUrl
-org.eclipse;albireo;0.0.3;Eclipse Public License - v 1.0;https://www.eclipse.org/legal/epl-v10.html
-org.antlr.runtime;'antlr!'';4.6.0;BSD;https://www.antlr.org/license.html
+﻿﻿org.eclipse;albireo;0.0.3;Eclipse Public License - v 1.0;https://www.eclipse.org/legal/epl-v10.html
+org.antlr.runtime;antlr;4.6.0;BSD;https://www.antlr.org/license.html
 org.eclipse.equinox.p2;Equinox p2 Provisioning for IDEs;2.3.2;Eclipse Public License - v 1.0;http://www.eclipse.org/legal/epl-v10.html
 org.springframework;spring;5.0.6;Apache 2;https://www.apache.org/licenses/LICENSE-2.0
-
-org.eclipse.xtend; xtend;2.2.0;MIT;https://spdx.org/licenses/MIT#licenseText
-#this is a comment
+org.eclipse.xtend;xtend;2.2.0;MIT;https://spdx.org/licenses/MIT#licenseText

--- a/documentation/files/csvlicenses.csv
+++ b/documentation/files/csvlicenses.csv
@@ -1,5 +1,8 @@
-﻿org.eclipse;albireo;0.0.3;Eclipse Public License - v 1.0;https://www.eclipse.org/legal/epl-v10.html
-org.antlr.runtime;antlr;4.6.0;BSD;https://www.antlr.org/license.html
+﻿groupId;ArtifactId;version;license;licenseUrl
+org.eclipse;albireo;0.0.3;Eclipse Public License - v 1.0;https://www.eclipse.org/legal/epl-v10.html
+org.antlr.runtime;'antlr!'';4.6.0;BSD;https://www.antlr.org/license.html
 org.eclipse.equinox.p2;Equinox p2 Provisioning for IDEs;2.3.2;Eclipse Public License - v 1.0;http://www.eclipse.org/legal/epl-v10.html
 org.springframework;spring;5.0.6;Apache 2;https://www.apache.org/licenses/LICENSE-2.0
-org.eclipse.xtend;xtend;2.2.0;MIT;https://spdx.org/licenses/MIT#licenseText
+
+org.eclipse.xtend; xtend;2.2.0;MIT;https://spdx.org/licenses/MIT#licenseText
+#this is a comment

--- a/documentation/files/csvreader.config
+++ b/documentation/files/csvreader.config
@@ -5,3 +5,4 @@ license:3
 licenseURL:4
 delimiter:;
 quote:
+skipheader:

--- a/documentation/files/csvreader.config
+++ b/documentation/files/csvreader.config
@@ -1,8 +1,0 @@
-groupID:0
-artifactID:1
-version:2
-license:3
-licenseURL:4
-delimiter:;
-quote:
-skipheader:

--- a/documentation/files/csvreader.config
+++ b/documentation/files/csvreader.config
@@ -1,0 +1,7 @@
+groupID:0
+artifactID:1
+version:2
+license:3
+licenseURL:4
+delimiter:;
+quote:

--- a/documentation/master-solicitor.asciidoc
+++ b/documentation/master-solicitor.asciidoc
@@ -490,7 +490,25 @@ The CSV input is normally manually generated and should look like this:
 include::files/csvlicenses.csv[]
 ----
 
-In _Solicitor_ the data is read with the following part of the config (configuration field includes optional parameters)
+In Solicitor the data is read with the following part of the config
+
+----
+"readers" : [ {
+  "type" : "csv",
+  "source" : "file:path/to/the/file.csv",
+  "usagePattern" : "DYNAMIC_LINKING"
+} ]
+----
+
+The following 5 columns need to be contained in order (separated with ";"):
+
+* groupId
+* artifactId
+* version
+* license name
+* license URL
+
+Additionally, an optional configuration can be set in order to customize the given structure of the csv file e.g.: 
 
 ----
 "readers" : [ {
@@ -508,12 +526,12 @@ In _Solicitor_ the data is read with the following part of the config (configura
 } ]
 ----
 
-The following 2 configuration settings need to be contained:
+The minimum of following 2 configuration settings need to be contained:
 
 * artifactId
 * version
 
-In these settings one can specify the position of the value within the csv file.
+With these settings one can specify the position of the value within the csv file.
 Additional positional settings include:
 
 * groupId
@@ -524,19 +542,30 @@ If a charset needs to be specified, one can use the following option:
 
 * charset (string, specified charset for reader e.g. UTF-8)
 
-Furthermore, one can configure a range of other options based on the https://commons.apache.org/proper/commons-csv/apidocs/org/apache/commons/csv/CSVFormat.Builder.html[Apache Commons CSV API]:
+Furthermore, one can configure a range of other csv structure options based on the https://commons.apache.org/proper/commons-csv/apidocs/org/apache/commons/csv/CSVFormat.Builder.html[Apache Commons CSV API]:
 
-* skipHeaderRecord (boolean)
-* delimiter (char)
+* allowDuplicateHeaderNames (boolean)
+* allowMissingColumnNames (boolean)
+* autoFlush (boolean)
+* commentMarker (char)
+* delimiter (string)
+* escape (char)
+* ignoreEmptyLines (boolean)
+* ignoreHeaderCase (boolean)
+* ignoreSurroundingSpaces (boolean)
+* nullString (string)
 * quote (char)
-* ...
+* recordSeparator (string)
+* skipHeaderRecord (boolean)
+* trailingDelimiter (boolean)
+* trim (boolean)
 
 These configurations may also be used to overwrite options of a https://commons.apache.org/proper/commons-csv/apidocs/org/apache/commons/csv/CSVFormat.Predefined.html[predefined format], which can be set with:
 
 * format (string, predefined format e.g. EXCEL)
 
-In case that a component has multiple licenses attached, there needs to be a separate
-line in the file for each license.
+Important: In case that a component has multiple licenses attached, there needs to be a separate
+line in the csv file for each license.
 
 === NPM
 

--- a/documentation/master-solicitor.asciidoc
+++ b/documentation/master-solicitor.asciidoc
@@ -490,7 +490,7 @@ The CSV input is normally manually generated and should look like this:
 include::files/csvlicenses.csv[]
 ----
 
-In Solicitor the data is read with the following part of the config
+In _Solicitor_ the data is read with the following part of the config
 
 ----
 "readers" : [ {

--- a/documentation/master-solicitor.asciidoc
+++ b/documentation/master-solicitor.asciidoc
@@ -1315,6 +1315,8 @@ If downloaded license texts contain large amounts of html formatted content they
 for cleanup. A warning message will be written in this case (SOLI-050).
 * https://github.com/devonfw/solicitor/issues/103:
 Changed structure of Solicitor source code repository to maven multi module structure.
+* https://github.com/devonfw/solicitor/issues/7:
+Allow more flexible CSV file format within the CsvReader. 
 
 Changes in 1.2.3::
 * https://github.com/devonfw/solicitor/issues/97: Fixed the bug which made the GradleReader and GradleReader2 skip the first entry in the file.

--- a/documentation/master-solicitor.asciidoc
+++ b/documentation/master-solicitor.asciidoc
@@ -483,30 +483,57 @@ In _Solicitor_ the data is read with the following reader config:
 (the above assumes that _Solicitor_ is executed in the maven projects main directory)
 
 === CSV
-The CSV input is normally manually generated and should look like this (The csv File is ";" separated):
+The CSV input is normally manually generated and should look like this:
 
 [source]
 ----
 include::files/csvlicenses.csv[]
 ----
 
-In _Solicitor_ the data is read with the following part of the config
+In _Solicitor_ the data is read with the following part of the config (configuration field includes optional parameters)
 
 ----
 "readers" : [ {
   "type" : "csv",
   "source" : "file:path/to/the/file.csv",
-  "usagePattern" : "DYNAMIC_LINKING"
+  "usagePattern" : "DYNAMIC_LINKING",
+  "configuration" : {
+	"charset" = "UTF-8",
+	"artifactId" : "0",
+	"version" : "1",
+	"format" : "EXCEL",
+	"skipHeaderRecord" : "true",
+	"delimiter" : ";"
+  }
 } ]
 ----
 
-The following 5 columns need to be contained:
+The following 2 configuration settings need to be contained:
 
-* groupId
 * artifactId
 * version
-* license name
-* license URL
+
+In these settings one can specify the position of the value within the csv file.
+Additional positional settings include:
+
+* groupId
+* license
+* licenseUrl
+
+If a charset needs to be specified, one can use the following option:
+
+* charset (string, specified charset for reader e.g. UTF-8)
+
+Furthermore, one can configure a range of other options based on the https://commons.apache.org/proper/commons-csv/apidocs/org/apache/commons/csv/CSVFormat.Builder.html[Apache Commons CSV API]:
+
+* skipHeaderRecord (boolean)
+* delimiter (char)
+* quote (char)
+* ...
+
+These configurations may also be used to overwrite options of a https://commons.apache.org/proper/commons-csv/apidocs/org/apache/commons/csv/CSVFormat.Predefined.html[predefined format], which can be set with:
+
+* format (string, predefined format e.g. EXCEL)
 
 In case that a component has multiple licenses attached, there needs to be a separate
 line in the file for each license.


### PR DESCRIPTION
This pull-request features fixes for the problems stated in Issue #7. 
It includes: 
- A configuration of the csv reader in which one can manually set options like: position of values,  used charset, predefined formats (https://commons.apache.org/proper/commons-csv/apidocs/org/apache/commons/csv/CSVFormat.Predefined.html), and other csv options like skipping the header line based on https://commons.apache.org/proper/commons-csv/apidocs/org/apache/commons/csv/CSVFormat.Builder.html. 
- Legacy Support for the previous csv reader (fixed structure of csv input file required)
- Updated documentation
- New version of commons-csv dependency