### PR TITLE
added stability / data corruption safety for bash scripts of scancode integration

### DIFF
--- a/core/src/main/resources/com/devonfw/tools/solicitor/templates/ScancodeScanScript.vm
+++ b/core/src/main/resources/com/devonfw/tools/solicitor/templates/ScancodeScanScript.vm
@@ -6,19 +6,22 @@ echo {\"artifacts\": [ > scancodeOutput/scancodeOut.json
 dir=$(pwd)/Source
 
 #foreach ($artifact in $ARTIFACTS)
-if [ ! -f $dir/$purlhandler.pathFor($artifact.packageUrl)/scancode.json ]
-		then
-	if [ -d $dir/$purlhandler.pathFor($artifact.packageUrl)/sources ]
-		then
+if [ ! -f $dir/$purlhandler.pathFor($artifact.packageUrl)/scancode.json ] || [ ! -f $dir/$purlhandler.pathFor($artifact.packageUrl)/scancodeScan.completed ]
+then
+	rm $dir/$purlhandler.pathFor($artifact.packageUrl)/scancodeScan.completed
+	rm $dir/$purlhandler.pathFor($artifact.packageUrl)/scancode.json
+	if [ -d $dir/$purlhandler.pathFor($artifact.packageUrl)/sources ] && [ -f $dir/$purlhandler.pathFor($artifact.packageUrl)/sources.completed ]
+	then
 		scancode $scancodeoptions --json-pp $dir/$purlhandler.pathFor($artifact.packageUrl)/scancode.json $dir/$purlhandler.pathFor($artifact.packageUrl)/sources
-		fi
+		touch $dir/$purlhandler.pathFor($artifact.packageUrl)/scancodeScan.completed
+	fi
+fi
+if 	[ -f $dir/$purlhandler.pathFor($artifact.packageUrl)/scancode.json ] && [ -f $dir/$purlhandler.pathFor($artifact.packageUrl)/scancodeScan.completed ]
 	cat $dir/$purlhandler.pathFor($artifact.packageUrl)/scancode.json >> $so/scancodeOut.json
-	if [ -f $dir/$purlhandler.pathFor($artifact.packageUrl)/scancode.json ]
-		then
-		printf "\n," >> $so/scancodeOut.json
-		fi
-		fi
-	#end
+	printf "\n," >> $so/scancodeOut.json
+fi
+#end
+	
 printf "END" >> $so/scancodeOut.json
 grep -v ",END" $so/scancodeOut.json > $so/scancodeOutput.json
 rm $so/scancodeOut.json

--- a/core/src/main/resources/com/devonfw/tools/solicitor/templates/ScancodeScanScript.vm
+++ b/core/src/main/resources/com/devonfw/tools/solicitor/templates/ScancodeScanScript.vm
@@ -17,6 +17,7 @@ then
 	fi
 fi
 if 	[ -f $dir/$purlhandler.pathFor($artifact.packageUrl)/scancode.json ] && [ -f $dir/$purlhandler.pathFor($artifact.packageUrl)/scancodeScan.completed ]
+then	
 	cat $dir/$purlhandler.pathFor($artifact.packageUrl)/scancode.json >> $so/scancodeOut.json
 	printf "\n," >> $so/scancodeOut.json
 fi

--- a/core/src/main/resources/com/devonfw/tools/solicitor/templates/ScancodeScript.vm
+++ b/core/src/main/resources/com/devonfw/tools/solicitor/templates/ScancodeScript.vm
@@ -20,7 +20,13 @@ echo "These artifacts need to be downloaded manually:" > need-to-retrieve-manual
 	if [ ! -d "$purlhandler.pathFor($artifact.packageUrl)" ]
 	then
 		mkdir -p $purlhandler.pathFor($artifact.packageUrl)
+	fi
+	if [ ! -f "$purlhandler.pathFor($artifact.packageUrl)/sources.completed" ] || [ ! -d "$purlhandler.pathFor($artifact.packageUrl)/sources" ]
+	then
 		cd $purlhandler.pathFor($artifact.packageUrl)
+		rm sources.completed
+		rm -r sources
+		rm sources.jar
 		curl -# $purlhandler.sourceDownloadUrlFor($artifact.packageUrl) -o sources.$purlhandler.sourceArchiveSuffixFor($artifact.packageUrl)
 		#if ( $purlhandler.sourceArchiveSuffixFor($artifact.packageUrl) == "jar" )
 		unzip -q -d sources sources.$purlhandler.sourceArchiveSuffixFor($artifact.packageUrl)
@@ -41,6 +47,7 @@ echo "These artifacts need to be downloaded manually:" > need-to-retrieve-manual
 			#[[cd $SD]]#
 			echo "Artifact $purlhandler.sourceDownloadUrlFor($artifact.packageUrl)" >> need-to-retrieve-manually.txt
 		else
+			touch sources.completed
 			#[[cd $SD]]#
 		fi
 	fi

--- a/documentation/master-solicitor.asciidoc
+++ b/documentation/master-solicitor.asciidoc
@@ -1486,6 +1486,7 @@ java -Dloader.path=path/to/the/extension.zip -jar solicitor.jar <any other argum
 == Release Notes
 
 Changes in 1.4.0::
+* Stability and data corruption safety for bash scripts of scancode integration.
 * Initial version of experimental scancode integration. See <<Experimental Scancode Integration>>.
 * New decision table structure `LicenseAssignmentV2` with additional condition `origin`.
 Old structure deprecated but still supported.


### PR DESCRIPTION
This new feature should allow the user to perform the scancode-related scripts without fear of data corruption / incomplete results due to crashes, early terminations etc. 
The scripts can now automatically recognize if a scan or source download was successfully performed, so even after restarting the scripts, the software will pick up the workload from where left off / crashed. Unfinished data will be removed and downloaded / scanned again.