### PR TITLE
Use STATIC_LINKING in configuration snippet for yarn reader

### DIFF
--- a/documentation/master-solicitor.asciidoc
+++ b/documentation/master-solicitor.asciidoc
@@ -706,7 +706,7 @@ In _Solicitor_ the data is read with the following part of the config
 "readers" : [ {
   "type" : "yarn",
   "source" : "file:path/to/yarnlicenses.json",
-  "usagePattern" : "DYNAMIC_LINKING",
+  "usagePattern" : "STATIC_LINKING",
   "repoType" : "yarn"
 } ]
 ----


### PR DESCRIPTION
The configuration snippet in the documentation of the YARN reader still showed DYNAMIC_LINKING instead of STATIC_LINKING (this was already corrected for the NPM readers).  This PR fixes this.