### PR TITLE
Do not raise NullPointer during GuessedLicenseUrlContent creation

### DIFF
--- a/core/src/main/java/com/devonfw/tools/solicitor/licensetexts/GuessedLicenseUrlContentFactory.java
+++ b/core/src/main/java/com/devonfw/tools/solicitor/licensetexts/GuessedLicenseUrlContentFactory.java
@@ -16,7 +16,7 @@ public class GuessedLicenseUrlContentFactory implements ContentFactory<GuessedLi
   @Override
   public GuessedLicenseUrlContent fromString(String string) {
 
-    if (string == null || string.isEmpty()) {
+    if (string == null || string.trim().isEmpty()) {
       return emptyContent();
     }
 

--- a/core/src/test/java/com/devonfw/tools/solicitor/licensetexts/GuessedLicenseUrlContentFactoryTest.java
+++ b/core/src/test/java/com/devonfw/tools/solicitor/licensetexts/GuessedLicenseUrlContentFactoryTest.java
@@ -82,4 +82,18 @@ public class GuessedLicenseUrlContentFactoryTest {
     assertNull(result.getGuessedUrl());
     assertNull(result.getAuditInfo());
   }
+
+  /**
+   * Test method for
+   * {@link com.devonfw.tools.solicitor.licensetexts.GuessedLicenseUrlContentFactory#fromString(java.lang.String)}.
+   */
+  @Test
+  public void testFromStringWithWhitespaces() {
+
+    GuessedLicenseUrlContentFactory factory = new GuessedLicenseUrlContentFactory();
+
+    GuessedLicenseUrlContent result = factory.fromString("            ");
+    assertNull(result.getGuessedUrl());
+    assertNull(result.getAuditInfo());
+  }
 }


### PR DESCRIPTION
If a licenseurls file is not properly formatted, e.g., contains only blanks, the GuessedLicenseUrlContent should be empty.

Solves #168 