### PR TITLE
Do not raise NullPointer during GuessedLicenseUrlContent creation

### DIFF
--- a/core/src/main/java/com/devonfw/tools/solicitor/licensetexts/GuessedLicenseUrlContentFactory.java
+++ b/core/src/main/java/com/devonfw/tools/solicitor/licensetexts/GuessedLicenseUrlContentFactory.java
@@ -16,7 +16,7 @@ public class GuessedLicenseUrlContentFactory implements ContentFactory<GuessedLi
   @Override
   public GuessedLicenseUrlContent fromString(String string) {
 
-    if (string == null || string.isEmpty()) {
+    if (string == null || string.trim().isEmpty()) {
       return emptyContent();
     }
 

--- a/core/src/test/java/com/devonfw/tools/solicitor/licensetexts/GuessedLicenseUrlContentFactoryTest.java
+++ b/core/src/test/java/com/devonfw/tools/solicitor/licensetexts/GuessedLicenseUrlContentFactoryTest.java
@@ -82,4 +82,18 @@ public class GuessedLicenseUrlContentFactoryTest {
     assertNull(result.getGuessedUrl());
     assertNull(result.getAuditInfo());
   }
+
+  /**
+   * Test method for
+   * {@link com.devonfw.tools.solicitor.licensetexts.GuessedLicenseUrlContentFactory#fromString(java.lang.String)}.
+   */
+  @Test
+  public void testFromStringWithWhitespaces() {
+
+    GuessedLicenseUrlContentFactory factory = new GuessedLicenseUrlContentFactory();
+
+    GuessedLicenseUrlContent result = factory.fromString("            ");
+    assertNull(result.getGuessedUrl());
+    assertNull(result.getAuditInfo());
+  }
 }

--- a/documentation/master-solicitor.asciidoc
+++ b/documentation/master-solicitor.asciidoc
@@ -1577,6 +1577,7 @@ Spring beans implementing this interface will be called at certain points in the
 == Release Notes
 Changes in 1.11.0::
 * https://github.com/devonfw/solicitor/pull/179: Added further name mapping rules.
+* https://github.com/devonfw/solicitor/issues/168: Fixed NullPointerException for blank license in License URL Guessing.
 
 Changes in 1.10.0::
 * https://github.com/devonfw/solicitor/issues/175: Introduce new properties `packageDownloadUrl` and `sourceDownloadUrl` in `ApplicationComponent`. Process file `origin.yaml` within <<Experimental Scancode Integration>> to be able to set these properties to non default values.  


### PR DESCRIPTION
If a licenseurls file is not properly formatted, e.g., contains only blanks, the GuessedLicenseUrlContent should be empty.

Solves https://github.com/devonfw/solicitor/issues/168