### PR TITLE
Add missing license texts for SAX-PD and W3C

### DIFF
--- a/core/src/test/resources/licenses/http___www_saxproject_org_copying_html
+++ b/core/src/test/resources/licenses/http___www_saxproject_org_copying_html
@@ -1,0 +1,26 @@
+Copyright Status
+SAX is free!
+
+In fact, it's not possible to own a license to SAX, since it's been placed in the public domain.
+
+No Warranty
+Because SAX is released to the public domain, there is no warranty for the design or for the software implementation, to the extent permitted by applicable law. Except when otherwise stated in writing the copyright holders and/or other parties provide SAX "as is" without warranty of any kind, either expressed or implied, including, but not limited to, the implied warranties of merchantability and fitness for a particular purpose. The entire risk as to the quality and performance of SAX is with you. Should SAX prove defective, you assume the cost of all necessary servicing, repair or correction.
+
+In no event unless required by applicable law or agreed to in writing will any copyright holder, or any other party who may modify and/or redistribute SAX, be liable to you for damages, including any general, special, incidental or consequential damages arising out of the use or inability to use SAX (including but not limited to loss of data or data being rendered inaccurate or losses sustained by you or third parties or a failure of the SAX to operate with any other programs), even if such holder or other party has been advised of the possibility of such damages.
+
+Copyright Disclaimers
+This page includes statements to that effect by David Megginson, who would have been able to claim copyright for the original work.
+
+SAX 1.0
+Version 1.0 of the Simple API for XML (SAX), created collectively by the membership of the XML-DEV mailing list, is hereby released into the public domain.
+
+No one owns SAX: you may use it freely in both commercial and non-commercial applications, bundle it with your software distribution, include it on a CD-ROM, list the source code in a book, mirror the documentation at your own web site, or use it in any other way you see fit.
+
+David Megginson, Megginson Technologies Ltd.
+1998-05-11
+
+SAX 2.0
+I hereby abandon any property rights to SAX 2.0 (the Simple API for XML), and release all of the SAX 2.0 source code, compiled code, and documentation contained in this distribution into the Public Domain. SAX comes with NO WARRANTY or guarantee of fitness for any purpose.
+
+David Megginson, Megginson Technologies Ltd.
+2000-05-05

--- a/core/src/test/resources/licenses/http___www_w3_org_TR_2004_REC_DOM_Level_3_Core_20040407_java_binding_zip
+++ b/core/src/test/resources/licenses/http___www_w3_org_TR_2004_REC_DOM_Level_3_Core_20040407_java_binding_zip
@@ -1,0 +1,18 @@
+W3C SOFTWARE NOTICE AND LICENSE
+Copyright © 2004 World Wide Web Consortium, (Massachusetts Institute of Technology, European Research Consortium for Informatics and Mathematics, Keio University). All Rights Reserved.
+The DOM bindings are published under the W3C Software Copyright Notice and License. The software license requires "Notice of any changes or modifications to the W3C files, including the date changes were made." Consequently, modified versions of the DOM bindings must document that they do not conform to the W3C standard; in the case of the IDL definitions, the pragma prefix can no longer be 'w3c.org'; in the case of the Java language binding, the package names can no longer be in the 'org.w3c' package.
+
+Note: The original version of the W3C Software Copyright Notice and License could be found at http://www.w3.org/Consortium/Legal/2002/copyright-software-20021231
+
+This work (and included software, documentation such as READMEs, or other related items) is being provided by the copyright holders under the following license. By obtaining, using and/or copying this work, you (the licensee) agree that you have read, understood, and will comply with the following terms and conditions.
+
+Permission to copy, modify, and distribute this software and its documentation, with or without modification, for any purpose and without fee or royalty is hereby granted, provided that you include the following on ALL copies of the software and documentation or portions thereof, including modifications:
+
+The full text of this NOTICE in a location viewable to users of the redistributed or derivative work.
+Any pre-existing intellectual property disclaimers, notices, or terms and conditions. If none exist, the W3C Software Short Notice should be included (hypertext is preferred, text is permitted) within the body of any redistributed or derivative code.
+Notice of any changes or modifications to the files, including the date changes were made. (We recommend you provide URIs to the location from which the code is derived.)
+THIS SOFTWARE AND DOCUMENTATION IS PROVIDED "AS IS," AND COPYRIGHT HOLDERS MAKE NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO, WARRANTIES OF MERCHANTABILITY OR FITNESS FOR ANY PARTICULAR PURPOSE OR THAT THE USE OF THE SOFTWARE OR DOCUMENTATION WILL NOT INFRINGE ANY THIRD PARTY PATENTS, COPYRIGHTS, TRADEMARKS OR OTHER RIGHTS.
+
+COPYRIGHT HOLDERS WILL NOT BE LIABLE FOR ANY DIRECT, INDIRECT, SPECIAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF ANY USE OF THE SOFTWARE OR DOCUMENTATION.
+
+The name and trademarks of copyright holders may NOT be used in advertising or publicity pertaining to the software without specific, written prior permission. Title to copyright in this software and any associated documentation will at all times remain with copyright holders.

--- a/core/src/test/resources/ownlicenseinfo/Solicitor_LicenseInfo_Template.vm
+++ b/core/src/test/resources/ownlicenseinfo/Solicitor_LicenseInfo_Template.vm
@@ -113,7 +113,7 @@ are at least partly licensed via the following license of type $nl:
 		#if ($nlc)
 		<table border="1">
 		<tr><td>
-			<pre>$esc.html($nlc)</pre>
+			<pre>$esc.html($esc.wrap100to80($nlc))</pre>
  		</td></tr>
 		</table>
 		#else


### PR DESCRIPTION
This fixes https://github.com/devonfw/solicitor/issues/187