### PR TITLE
Improvement in determining License-URL within NpmLicenseCheckerReader

### DIFF
--- a/core/src/main/java/com/devonfw/tools/solicitor/reader/npmlicensechecker/NpmLicenseCheckerReader.java
+++ b/core/src/main/java/com/devonfw/tools/solicitor/reader/npmlicensechecker/NpmLicenseCheckerReader.java
@@ -132,7 +132,15 @@ public class NpmLicenseCheckerReader extends AbstractReader implements Reader {
         repo = repo.substring(0, repo.length() - 1);
       }
       if (repo.contains("github.com")) {
-        return repo.replace("git://", "https://") + "/raw/master" + licenseRelative;
+        if (repo.contains("/tree")) {
+          return repo.replace("git://", "https://").replace("github.com", "raw.githubusercontent.com").replace("/tree",
+              "") + licenseRelative;
+
+        } else {
+          return repo.replace("git://", "https://").replace("github.com", "raw.githubusercontent.com") + "/master"
+              + licenseRelative;
+
+        }
       }
     }
     return repo;

--- a/core/src/test/java/com/devonfw/tools/solicitor/reader/npmlicensechecker/NpmLicenseCheckerReaderTests.java
+++ b/core/src/test/java/com/devonfw/tools/solicitor/reader/npmlicensechecker/NpmLicenseCheckerReaderTests.java
@@ -139,8 +139,8 @@ public class NpmLicenseCheckerReaderTests {
     List<ApplicationComponent> lapc = this.application.getApplicationComponents();
     boolean found = false;
     for (ApplicationComponent ap : lapc) {
-      if (ap.getArtifactId().equals("foo")
-          && ap.getRawLicenses().get(0).getLicenseUrl().equals("https://github.com/somebody/foo/raw/master/LICENSE")) {
+      if (ap.getArtifactId().equals("foo") && ap.getRawLicenses().get(0).getLicenseUrl()
+          .equals("https://raw.githubusercontent.com/somebody/foo/master/LICENSE")) {
         found = true;
         break;
       }

--- a/documentation/master-solicitor.asciidoc
+++ b/documentation/master-solicitor.asciidoc
@@ -1614,6 +1614,7 @@ Spring beans implementing this interface will be called at certain points in the
 [appendix]
 == Release Notes
 Changes in 1.16.0::
+* https://github.com/devonfw/solicitor/pull/212: Improvement in determining License-URL within NpmLicenseCheckerReader.
 
 Changes in 1.15.0::
 * https://github.com/devonfw/solicitor/issues/208: Add two new lifecycle methods to `SolicitorLifecycleListener`.


### PR DESCRIPTION
The up to now mapping of the data of the NpmLicenceChecker plugin to the LicenseUrl leads to a lot of Urls which can not be accessed. This change improves this and results in a higher success rate.