### PR TITLE
Update dependencies and plugins

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>2.6.3</version>
+    <version>2.7.17</version>
     <relativePath/>
     <!-- lookup parent from repository -->
   </parent>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -98,12 +98,12 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-csv</artifactId>
-      <version>1.9.0</version>
+      <version>1.10.0</version>
     </dependency>
     <dependency>
       <groupId>commons-codec</groupId>
       <artifactId>commons-codec</artifactId>
-      <version>1.15</version>
+      <version>1.16.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.velocity</groupId>
@@ -130,7 +130,7 @@
     <dependency>
       <groupId>commons-cli</groupId>
       <artifactId>commons-cli</artifactId>
-      <version>1.5.0</version>
+      <version>1.6.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
@@ -161,7 +161,7 @@
     <dependency>
       <groupId>com.auth0</groupId>
       <artifactId>java-jwt</artifactId>
-      <version>4.2.1</version>
+      <version>4.4.0</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
@@ -231,7 +231,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>license-maven-plugin</artifactId>
-        <version>2.0.0</version>
+        <version>2.3.0</version>
         <executions>
           <execution>
             <phase>validate</phase>

--- a/documentation/master-solicitor.asciidoc
+++ b/documentation/master-solicitor.asciidoc
@@ -1615,6 +1615,7 @@ Spring beans implementing this interface will be called at certain points in the
 == Release Notes
 Changes in 1.16.0::
 * https://github.com/devonfw/solicitor/pull/212: Improvement in determining License-URL within NpmLicenseCheckerReader.
+* https://github.com/devonfw/solicitor/issues/218: Update dependencies to latest version.
 
 Changes in 1.15.0::
 * https://github.com/devonfw/solicitor/issues/208: Add two new lifecycle methods to `SolicitorLifecycleListener`.

--- a/documentation/pom.xml
+++ b/documentation/pom.xml
@@ -25,9 +25,9 @@
   </scm>
 
   <properties>
-    <asciidoctor.maven.plugin.version>2.2.2</asciidoctor.maven.plugin.version>
-    <asciidoctorj.pdf.version>1.6.2</asciidoctorj.pdf.version>
-    <asciidoctorj.version>2.5.3</asciidoctorj.version>
+    <asciidoctor.maven.plugin.version>2.2.4</asciidoctor.maven.plugin.version>
+    <asciidoctorj.pdf.version>2.3.9</asciidoctorj.pdf.version>
+    <asciidoctorj.version>2.5.10</asciidoctorj.version>
     <jruby.version>9.3.3.0</jruby.version>
     <maven.build.timestamp.format>dd-MM-yy_HH:mm</maven.build.timestamp.format>
     <builddate>${maven.build.timestamp}</builddate>
@@ -56,7 +56,7 @@
                       asciidoctor-maven-plugin
                     </artifactId>
                     <versionRange>
-                      [2.2.2,)
+                      [2.2.4,)
                     </versionRange>
                     <goals>
                       <goal>
@@ -169,7 +169,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>
-        <version>3.3.0</version>
+        <version>3.4.0</version>
         <executions>
           <execution>
             <id>attach-doc</id>

--- a/documentation/pom.xml
+++ b/documentation/pom.xml
@@ -154,8 +154,8 @@
               <sourceHighlighter>coderay</sourceHighlighter>
               <doctype>book</doctype>
               <attributes>
-                <pdf-stylesdir>${project.basedir}/theme</pdf-stylesdir>
-                <pdf-style>solicitor</pdf-style>
+                <pdf-themesdir>${project.basedir}/theme</pdf-themesdir>
+                <pdf-theme>solicitor</pdf-theme>
                 <icons>font</icons>
                 <pagenums/>
                 <toc/>


### PR DESCRIPTION
Ticket: https://github.com/devonfw/solicitor/issues/218.

Updated dependencies and plugins.

| GroupID       | ArtifactID                  | Old Version | New Version |
|---------------------|---------------------------|-------------|-------------|
| org.springframework  | spring-boot-starter-parent | 2.6.3       | 2.7.17      |
| org.apache.commons  | commons-csv               | 1.9.0       | 1.10.0      |
| commons-codec       | commons-codec             | 1.15        | 1.16.0      |
| commons-cli         | commons-cli               | 1.5.0       | 1.6.0       |
| com.auth0           | java-jwt                  | 4.2.1       | 4.4.0       |
| org.codehaus.mojo    | license-maven-plugin      | 2.0.0       | 2.3.0       |
| org.asciidoctor     | asciidoctor-maven-plugin  | 2.2.2       | 2.2.4       |
| org.asciidoctor     | asciidoctorj-pdf          | 1.6.2       | 2.3.9       |
| org.asciidoctor     | asciidoctorj              | 2.5.3       | 2.5.10      |
| org.codehaus.mojo    | build-helper-maven-plugin | 3.3.0       | 3.4.0       |

_spring-boot is only updated to latest stable 2.7 version because springboot 3.0+ requires java 17._

Dependencies / plugins that cause a break when updating.
| GroupID               | ArtifactID                  | Old Version  | New Version    |
|------------------------|---------------------------|--------------|----------------|
| org.kie                | kie-ci                    | 8.16.1.Beta  | 9.44.0.Final   |
| org.drools             | drools-decisiontables     | 8.16.1.Beta  | 9.44.0.Final   |
| org.drools             | drools-xml-support        | 8.16.1.Beta  | 9.44.0.Final   |
| org.apache.poi         | poi-ooxml                 | 5.2.0        | 5.2.4          |
| org.apache.poi         | poi                       | 5.2.0        | 5.2.4          |
| org.apache.velocity    | velocity-tools            | 2.0          | 3.1            |
| org.apache.maven       | maven-artifact            | 3.8.4        | 3.9.5          |
| com.sun.xml.bind       | jaxb-core                 | 3.0.2        | 4.0.4          |
| com.sun.xml.bind       | jaxb-impl                 | 3.0.2        | 4.0.4          |
| org.codehaus.mojo       | buildnumber-maven-plugin  | 1.4          | 3.2.0          |
| org.apache.xmlgraphics  | batik-all                 | 1.14         | 1.17           |
| org.jruby               | jruby-complete            | 9.3.3.0      | 9.4.5.0        |

