### PR TITLE
Introduce dataStatus prefix NL if no licenses were obtained from scancode

### DIFF
--- a/core/src/main/java/com/devonfw/tools/solicitor/componentinfo/ComponentInfoInventoryProcessor.java
+++ b/core/src/main/java/com/devonfw/tools/solicitor/componentinfo/ComponentInfoInventoryProcessor.java
@@ -41,7 +41,8 @@ public class ComponentInfoInventoryProcessor implements InventoryProcessor {
   }
 
   /**
-   * Prefix used for {@link ApplicationComponent#getDataStatus()} in case that data is available.
+   * Prefix used for {@link ApplicationComponent#getDataStatus()} in case that data is available. In this case the
+   * information as obtained from the Readers is preserved.
    */
   private static final String DA_STATUS_PREFIX = "DA:";
 
@@ -49,6 +50,12 @@ public class ComponentInfoInventoryProcessor implements InventoryProcessor {
    * Prefix used for {@link ApplicationComponent#getDataStatus()} in case that no data is available.
    */
   private static final String ND_STATUS_PREFIX = "ND:";
+
+  /**
+   * Prefix used for {@link ApplicationComponent#getDataStatus()} in case data is available but does not contain any
+   * license information. In this case the license information (RawLicenses) as obtained from the Readers is prserved.
+   */
+  private static final String NL_STATUS_PREFIX = "NL:";
 
   /**
    * Origin data for raw license objects created by this Class. Due to compatibility reasons this is named "scancode"
@@ -166,6 +173,8 @@ public class ComponentInfoInventoryProcessor implements InventoryProcessor {
         } else {
           LOG.info(LogMessages.COMPONENTINFO_NO_LICENSES.msg(),
               (ac.getGroupId() != null ? ac.getGroupId() + "/" : "") + ac.getArtifactId() + "/" + ac.getVersion());
+          // Correct dataStatus
+          ac.setDataStatus(NL_STATUS_PREFIX + componentInfo.getDataStatus());
           for (RawLicense rl : ac.getRawLicenses()) {
             String trace = rl.getTrace() + System.lineSeparator()
                 + "+ ComponentInfo available but without license information - keeping data from Reader";

--- a/documentation/master-solicitor.asciidoc
+++ b/documentation/master-solicitor.asciidoc
@@ -1434,12 +1434,15 @@ When using the Scancode integration the following values are used for field `App
 [width="100%",cols="1,3",options="header"]
 |====================
 | Value | Description
-| `ND:DISABLED` | No data available. Scancode integration disabled.
-| `ND:NOT_AVAILABLE` | No data available. No scan results existing and no indication that attempting download/scanning has failed.
-| `ND:PROCESSING_FAILED` | No data available. No scan results existing. Processing (downloading or scanning) had failed.
-| `DA:WITH_ISSUES` | Data available. Issues were detected in the data which probably need to be curated.
-| `DA:NO_ISSUES` | Data available. No curations applied. No issues were detected.
-| `DA:CURATED` | Data available. Curations were applied. No issues were detected.
+| `ND:DISABLED` | No data available. Scancode integration disabled. License info from reader was preserved.
+| `ND:NOT_AVAILABLE` | No data available. No scan results existing and no indication that attempting download/scanning has failed. License info from reader was preserved.
+| `ND:PROCESSING_FAILED` | No data available. No scan results existing. Processing (downloading or scanning) had failed. License info from reader was preserved.
+| `NL:WITH_ISSUES` | Data available but did not contain any license infos. Issues were detected in the data which probably need to be curated. License info from reader was preserved.
+| `NL:NO_ISSUES` | Data available but did not contain any license infos. No curations applied. No issues were detected (despite the fact that no license info was found). License info from reader was preserved.
+| `NL:CURATED` | Data available but did not contain any license infos. Curations were applied. No issues were detected (despite the fact that no license info was found). License info from reader was preserved.
+| `DA:WITH_ISSUES` | Data available (including licenses). Issues were detected in the data which probably need to be curated.
+| `DA:NO_ISSUES` | Data available (including licenses). No curations applied. No issues were detected.
+| `DA:CURATED` | Data available (including licenses). Curations were applied. No issues were detected.
 |====================
 
 === Correcting data
@@ -1637,6 +1640,7 @@ Spring beans implementing this interface will be called at certain points in the
 == Release Notes
 Changes in 1.19.0::
 * https://github.com/devonfw/solicitor/issues/227: Fixed a bug where the `dataStatus` field in the aggregated OSS-Inventory was not filled.
+* https://github.com/devonfw/solicitor/issues/228: Extended `ApplicationComponent.dataStatus` values to reflect situation when no licenses were obtained from the Scancode information. See <<dataStatus values of the Scancode integration>>.
 
 Changes in 1.18.0::
 * https://github.com/devonfw/solicitor/pull/225: Added some additional name mapping rules to handle SPDX-IDs and license references from Scancode.


### PR DESCRIPTION
This implements #228 .