### PR TITLE
Avoid path traversal threats

### DIFF
--- a/core/src/main/java/com/devonfw/tools/solicitor/common/IOHelper.java
+++ b/core/src/main/java/com/devonfw/tools/solicitor/common/IOHelper.java
@@ -85,17 +85,17 @@ public class IOHelper {
   }
 
   /**
-   * Create a path from the given base path and all provided relative paths. The method assures that each relative path
-   * applied to the already existing (intermediate) path does not point to some place outside the existing path.
+   * Create a file path from the given base path and all provided relative paths. The method assures that each relative
+   * path applied to the already existing (intermediate) path does not point to some place outside the existing path.
    *
-   * @param basePath the base path
-   * @param relativePaths any number of relative paths to be appended
-   * @return a path built from the given arguments
+   * @param basePath the base file path
+   * @param relativePaths any number of relative file paths to be appended
+   * @return a file path built from the given arguments
    * @throws IllegalArgumentException if any of the relativePaths points to some point outside the already existing path
    *         or if any of the relativePaths are absolute paths.
    * @throws NullPointerException if the basePath or any of the relativePaths are <code>null</code>
    */
-  public static String securePath(String basePath, String... relativePaths) {
+  public static String secureFilePath(String basePath, String... relativePaths) {
 
     if (basePath == null) {
       throw new NullPointerException("Base path must not be null");

--- a/core/src/main/java/com/devonfw/tools/solicitor/common/LogMessages.java
+++ b/core/src/main/java/com/devonfw/tools/solicitor/common/LogMessages.java
@@ -103,7 +103,8 @@ public enum LogMessages {
   MODERN_YARN_VIRTUAL_PACKAGE(69,
       "When reading yarn license info from file '{}' there was at least one virtual package encountered. Check if package resolution is correct"), //
   MODERN_YARN_PATCHED_PACKAGE(70,
-      "When reading yarn license info from file '{}' there was at least one patched package encountered. Processing only the base package, not the patched version.");
+      "When reading yarn license info from file '{}' there was at least one patched package encountered. Processing only the base package, not the patched version."), //
+  FAILED_READING_FILE(71, "Reading file '{}' failed");
 
   private final String message;
 

--- a/core/src/main/java/com/devonfw/tools/solicitor/common/content/FilesystemCachingContentProvider.java
+++ b/core/src/main/java/com/devonfw/tools/solicitor/common/content/FilesystemCachingContentProvider.java
@@ -67,7 +67,7 @@ public class FilesystemCachingContentProvider<C extends Content> extends Caching
 
     if (!url.startsWith("file:")) {
       // data of URLs which resolve to local file will not be cached
-      File file = new File(IOHelper.securePath(this.resourceDirectory, getKey(url)));
+      File file = new File(IOHelper.secureFilePath(this.resourceDirectory, getKey(url)));
       File targetDir = file.getParentFile();
       try {
         IOHelper.checkAndCreateLocation(file);

--- a/core/src/main/java/com/devonfw/tools/solicitor/common/content/FilesystemCachingContentProvider.java
+++ b/core/src/main/java/com/devonfw/tools/solicitor/common/content/FilesystemCachingContentProvider.java
@@ -67,7 +67,7 @@ public class FilesystemCachingContentProvider<C extends Content> extends Caching
 
     if (!url.startsWith("file:")) {
       // data of URLs which resolve to local file will not be cached
-      File file = new File(this.resourceDirectory + "/" + getKey(url));
+      File file = new File(IOHelper.securePath(this.resourceDirectory, getKey(url)));
       File targetDir = file.getParentFile();
       try {
         IOHelper.checkAndCreateLocation(file);

--- a/core/src/main/java/com/devonfw/tools/solicitor/common/content/web/DirectUrlWebContentProvider.java
+++ b/core/src/main/java/com/devonfw/tools/solicitor/common/content/web/DirectUrlWebContentProvider.java
@@ -26,6 +26,9 @@ public class DirectUrlWebContentProvider implements ContentProvider<WebContent> 
 
   private boolean skipdownload;
 
+  private static final Pattern SUPPORTED_URL_PATTERNS = Pattern.compile("^http:.*|^https:.*|^jar:http:.*|^jar:https:.*",
+      Pattern.CASE_INSENSITIVE);
+
   /**
    * Constructor.
    *
@@ -40,13 +43,18 @@ public class DirectUrlWebContentProvider implements ContentProvider<WebContent> 
   /**
    * {@inheritDoc}
    *
-   * Directly tries to access the given URL via the web.
+   * Directly tries to access the given URL via the web. Only URLs matching {@link #SUPPORTED_URL_PATTERNS} will be
+   * processed. All others return an empty WebContent.
    */
   @Override
   public WebContent getContentForUri(String url) {
 
     URL webContentUrl;
     if (url == null) {
+      return new WebContent(null);
+    }
+    if (!isSupportedUrl(url)) {
+      LOG.debug("Accessing URL '{}' is not supported by DirectUrlWebContentProvider, returning empty WebContent", url);
       return new WebContent(null);
     }
     if (this.skipdownload) {
@@ -82,6 +90,17 @@ public class DirectUrlWebContentProvider implements ContentProvider<WebContent> 
       LOG.info(LogMessages.COULD_NOT_DOWNLOAD_CONTENT.msg(), url, e.getClass().getSimpleName());
     }
     return new WebContent(null);
+  }
+
+  /**
+   * Indicates if the given URL is supported by this {@link ContentProvider}.
+   *
+   * @param url the url to check
+   * @return <code>true</code> if url is supported, <code>false</code> otherwise.
+   */
+  boolean isSupportedUrl(String url) {
+
+    return SUPPORTED_URL_PATTERNS.matcher(url).matches();
   }
 
   /**

--- a/core/src/main/java/com/devonfw/tools/solicitor/componentinfo/scancode/FileScancodeRawComponentInfoProvider.java
+++ b/core/src/main/java/com/devonfw/tools/solicitor/componentinfo/scancode/FileScancodeRawComponentInfoProvider.java
@@ -174,7 +174,7 @@ public class FileScancodeRawComponentInfoProvider implements ScancodeRawComponen
       return null;
     }
     if (fileUri.contains("..")) {
-      // prevent directory traversal (there are other measures to also prevent this, but lets do it here explicitely)
+      // prevent directory traversal (there are other measures to also prevent this, but lets do it here explicitly)
       LOG.debug("Suspicious file traversal in URI '{}', returning null", fileUri);
       return null;
     }

--- a/core/src/main/java/com/devonfw/tools/solicitor/componentinfo/scancode/FileScancodeRawComponentInfoProvider.java
+++ b/core/src/main/java/com/devonfw/tools/solicitor/componentinfo/scancode/FileScancodeRawComponentInfoProvider.java
@@ -77,7 +77,7 @@ public class FileScancodeRawComponentInfoProvider implements ScancodeRawComponen
       throws ComponentInfoAdapterException, ScancodeProcessingFailedException {
 
     String packagePathPart = this.packageURLHandler.pathFor(packageUrl);
-    String path = IOHelper.securePath(this.repoBasePath, packagePathPart, "scancode.json");
+    String path = IOHelper.secureFilePath(this.repoBasePath, packagePathPart, "scancode.json");
 
     File scanCodeFile = new File(path);
     if (!scanCodeFile.exists()) {
@@ -110,13 +110,13 @@ public class FileScancodeRawComponentInfoProvider implements ScancodeRawComponen
       throws ScancodeProcessingFailedException {
 
     // Check if "sources.failed" exists
-    String sourcesFailedPath = IOHelper.securePath(this.repoBasePath, packagePathPart, "sources.failed");
+    String sourcesFailedPath = IOHelper.secureFilePath(this.repoBasePath, packagePathPart, "sources.failed");
     File sourcesFailedFile = new File(sourcesFailedPath);
     if (sourcesFailedFile.exists()) {
       throw new ScancodeProcessingFailedException("Downloading of package sources had failed.");
     }
     // Check if "scancodeScan.failed" exists
-    String scancodeScanFailedPath = IOHelper.securePath(this.repoBasePath, packagePathPart, "scancodeScan.failed");
+    String scancodeScanFailedPath = IOHelper.secureFilePath(this.repoBasePath, packagePathPart, "scancodeScan.failed");
     File scancodeScanFailedFile = new File(scancodeScanFailedPath);
     if (scancodeScanFailedFile.exists()) {
       throw new ScancodeProcessingFailedException("Scanning of package sources had failed.");
@@ -134,7 +134,7 @@ public class FileScancodeRawComponentInfoProvider implements ScancodeRawComponen
       throws ComponentInfoAdapterException {
 
     String packagePathPart = this.packageURLHandler.pathFor(packageUrl);
-    String path = IOHelper.securePath(this.repoBasePath, packagePathPart, "origin.yaml");
+    String path = IOHelper.secureFilePath(this.repoBasePath, packagePathPart, "origin.yaml");
 
     File originFile = new File(path);
     if (!originFile.exists()) {
@@ -188,7 +188,7 @@ public class FileScancodeRawComponentInfoProvider implements ScancodeRawComponen
       relativeFilePathAndName = pkgContentUriWithoutPrefix.substring(0, startOfLineInfo);
     }
 
-    String fullFilePathAndName = IOHelper.securePath(this.repoBasePath, this.packageURLHandler.pathFor(packageUrl),
+    String fullFilePathAndName = IOHelper.secureFilePath(this.repoBasePath, this.packageURLHandler.pathFor(packageUrl),
         SOURCES_DIR, relativeFilePathAndName);
     File file = new File(fullFilePathAndName);
     try (InputStream is = new FileInputStream(file); Scanner s = new Scanner(is)) {

--- a/core/src/main/java/com/devonfw/tools/solicitor/componentinfo/scancode/MultilineHelper.java
+++ b/core/src/main/java/com/devonfw/tools/solicitor/componentinfo/scancode/MultilineHelper.java
@@ -1,0 +1,53 @@
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.devonfw.tools.solicitor.componentinfo.scancode;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * A helper class which supports extracting a range of lines from a given (multiline) string.
+ */
+public class MultilineHelper {
+
+  /**
+   * Constructor. Prevents instantiation.
+   *
+   */
+  private MultilineHelper() {
+
+  }
+
+  /**
+   * Extracts a range of lines from the given (multiline) input.
+   *
+   * @param input the multiline input
+   * @param lineInfo lines to extract, given as <code>#L17-L20</code>. <code>null</code> indicates that the whole input
+   *        should be returned.
+   * @return the extracted lines.
+   */
+  public static String possiblyExtractLines(String input, String lineInfo) {
+
+    if (lineInfo == null) {
+      return input;
+    }
+    Pattern pattern = Pattern.compile("#L(\\d+)(-L(\\d+))?");
+    Matcher matcher = pattern.matcher(lineInfo);
+    if (matcher.find()) {
+      int startLine = Integer.parseInt(matcher.group(1));
+      int endLine = Integer.parseInt(matcher.group(3) != null ? matcher.group(3) : matcher.group(1));
+      String[] splitted = input.split("\\n");
+      StringBuffer result = new StringBuffer();
+      for (int i = 0; i < splitted.length; i++) {
+        if (i + 1 >= startLine && i + 1 <= endLine) {
+          result.append(splitted[i]).append("\n");
+        }
+      }
+      return result.toString();
+    } else {
+      throw new IllegalStateException("Regex did not find line info - this seems to be a bug.");
+    }
+  }
+
+}

--- a/core/src/test/java/com/devonfw/tools/solicitor/common/IOHelperTest.java
+++ b/core/src/test/java/com/devonfw/tools/solicitor/common/IOHelperTest.java
@@ -24,33 +24,33 @@ class IOHelperTest {
 
   /**
    * Test method for
-   * {@link com.devonfw.tools.solicitor.common.IOHelper#securePath(java.lang.String, java.lang.String[])}.
+   * {@link com.devonfw.tools.solicitor.common.IOHelper#secureFilePath(java.lang.String, java.lang.String[])}.
    */
   @Test
-  void testSecurePath() {
+  void testSecureFilePath() {
 
-    assertEquals(fixSep("base"), IOHelper.securePath("base"));
-    assertEquals(fixSep("base/r1"), IOHelper.securePath("base", "r1"));
-    assertEquals(fixSep("base/r1/r2"), IOHelper.securePath("base", "r1", "r2"));
-    assertEquals(fixSep("base/r1/r2"), IOHelper.securePath("base", "r1///", "r2/././"));
-    assertEquals(fixSep("/base/r1/r2"), IOHelper.securePath("/base", "r1///", "r2/././"));
+    assertEquals(fixSep("base"), IOHelper.secureFilePath("base"));
+    assertEquals(fixSep("base/r1"), IOHelper.secureFilePath("base", "r1"));
+    assertEquals(fixSep("base/r1/r2"), IOHelper.secureFilePath("base", "r1", "r2"));
+    assertEquals(fixSep("base/r1/r2"), IOHelper.secureFilePath("base", "r1///", "r2/././"));
+    assertEquals(fixSep("/base/r1/r2"), IOHelper.secureFilePath("/base", "r1///", "r2/././"));
 
     assertThrows(IllegalArgumentException.class, () -> {
-      IOHelper.securePath("base", "/r1", "r2");
+      IOHelper.secureFilePath("base", "/r1", "r2");
     });
 
     assertThrows(IllegalArgumentException.class, () -> {
-      IOHelper.securePath("base", "../r1", "r2");
+      IOHelper.secureFilePath("base", "../r1", "r2");
     });
 
     assertThrows(IllegalArgumentException.class, () -> {
-      IOHelper.securePath("base", "r1", "../r2");
+      IOHelper.secureFilePath("base", "r1", "../r2");
     });
 
-    assertEquals(fixSep("base/r1/r2"), IOHelper.securePath("base", "a/../r1", "r2"));
+    assertEquals(fixSep("base/r1/r2"), IOHelper.secureFilePath("base", "a/../r1", "r2"));
 
     assertThrows(IllegalArgumentException.class, () -> {
-      IOHelper.securePath("base", "a/../../r1", "r2");
+      IOHelper.secureFilePath("base", "a/../../r1", "r2");
     });
   }
 

--- a/core/src/test/java/com/devonfw/tools/solicitor/common/IOHelperTest.java
+++ b/core/src/test/java/com/devonfw/tools/solicitor/common/IOHelperTest.java
@@ -1,0 +1,69 @@
+package com.devonfw.tools.solicitor.common;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.io.File;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link IOHelper}.
+ *
+ */
+class IOHelperTest {
+
+  /**
+   * @throws java.lang.Exception
+   */
+  @BeforeEach
+  void setUp() throws Exception {
+
+  }
+
+  /**
+   * Test method for
+   * {@link com.devonfw.tools.solicitor.common.IOHelper#securePath(java.lang.String, java.lang.String[])}.
+   */
+  @Test
+  void testSecurePath() {
+
+    assertEquals(fixSep("base"), IOHelper.securePath("base"));
+    assertEquals(fixSep("base/r1"), IOHelper.securePath("base", "r1"));
+    assertEquals(fixSep("base/r1/r2"), IOHelper.securePath("base", "r1", "r2"));
+    assertEquals(fixSep("base/r1/r2"), IOHelper.securePath("base", "r1///", "r2/././"));
+    assertEquals(fixSep("/base/r1/r2"), IOHelper.securePath("/base", "r1///", "r2/././"));
+
+    assertThrows(IllegalArgumentException.class, () -> {
+      IOHelper.securePath("base", "/r1", "r2");
+    });
+
+    assertThrows(IllegalArgumentException.class, () -> {
+      IOHelper.securePath("base", "../r1", "r2");
+    });
+
+    assertThrows(IllegalArgumentException.class, () -> {
+      IOHelper.securePath("base", "r1", "../r2");
+    });
+
+    assertEquals(fixSep("base/r1/r2"), IOHelper.securePath("base", "a/../r1", "r2"));
+
+    assertThrows(IllegalArgumentException.class, () -> {
+      IOHelper.securePath("base", "a/../../r1", "r2");
+    });
+  }
+
+  /**
+   * Returns the given strings with all occurrences of <code>/</code> or <code>\\</code> to be replaced by the system
+   * dependent file separator character. This is required to handle differences between Windows and Unix.
+   *
+   * @param input the origin string
+   * @return the fixed string
+   */
+  private static String fixSep(String input) {
+
+    return input.replace('/', File.separatorChar).replace('\\', File.separatorChar);
+  }
+
+}

--- a/core/src/test/java/com/devonfw/tools/solicitor/common/content/web/DirectUrlWebContentProviderTest.java
+++ b/core/src/test/java/com/devonfw/tools/solicitor/common/content/web/DirectUrlWebContentProviderTest.java
@@ -1,0 +1,35 @@
+package com.devonfw.tools.solicitor.common.content.web;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link DirectUrlWebContentProvider}
+ *
+ */
+class DirectUrlWebContentProviderTest {
+
+  /**
+   * Test method for
+   * {@link com.devonfw.tools.solicitor.common.content.web.DirectUrlWebContentProvider#isSupportedUrl(java.lang.String)}.
+   */
+  @Test
+  void testIsSupportedUrl() {
+
+    DirectUrlWebContentProvider provider = new DirectUrlWebContentProvider(false);
+
+    assertTrue(provider.isSupportedUrl("http:foo"));
+    assertTrue(provider.isSupportedUrl("https:foo"));
+    assertTrue(provider.isSupportedUrl("jar:http:foo"));
+    assertTrue(provider.isSupportedUrl("jar:https:foo"));
+
+    assertTrue(provider.isSupportedUrl("hTTp:foo"));
+
+    assertFalse(provider.isSupportedUrl("file:some.file"));
+    assertFalse(provider.isSupportedUrl("file:http:foo"));
+
+  }
+
+}

--- a/core/src/test/java/com/devonfw/tools/solicitor/componentinfo/scancode/FilteredScancodeComponentInfoProviderTests.java
+++ b/core/src/test/java/com/devonfw/tools/solicitor/componentinfo/scancode/FilteredScancodeComponentInfoProviderTests.java
@@ -7,7 +7,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
-import com.devonfw.tools.solicitor.common.content.web.DirectUrlWebContentProvider;
 import com.devonfw.tools.solicitor.common.packageurl.AllKindsPackageURLHandler;
 import com.devonfw.tools.solicitor.componentinfo.ComponentInfo;
 import com.devonfw.tools.solicitor.componentinfo.ComponentInfoAdapterException;
@@ -32,10 +31,8 @@ public class FilteredScancodeComponentInfoProviderTests {
 
     Mockito.when(packageURLHandler.pathFor("pkg:maven/com.devonfw.tools/test-project-for-deep-license-scan@0.1.0"))
         .thenReturn("pkg/maven/com/devonfw/tools/test-project-for-deep-license-scan/0.1.0");
-    DirectUrlWebContentProvider contentProvider = new DirectUrlWebContentProvider(false);
 
-    this.fileScancodeRawComponentInfoProvider = new FileScancodeRawComponentInfoProvider(contentProvider,
-        packageURLHandler);
+    this.fileScancodeRawComponentInfoProvider = new FileScancodeRawComponentInfoProvider(packageURLHandler);
     this.fileScancodeRawComponentInfoProvider.setRepoBasePath("src/test/resources/scancodefileadapter/Source/repo");
 
     this.singleFileCurationProvider = new SingleFileCurationProvider(packageURLHandler);

--- a/core/src/test/java/com/devonfw/tools/solicitor/componentinfo/scancode/ScancodeComponentInfoAdapterTest.java
+++ b/core/src/test/java/com/devonfw/tools/solicitor/componentinfo/scancode/ScancodeComponentInfoAdapterTest.java
@@ -13,7 +13,6 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
-import com.devonfw.tools.solicitor.common.content.web.DirectUrlWebContentProvider;
 import com.devonfw.tools.solicitor.common.packageurl.AllKindsPackageURLHandler;
 import com.devonfw.tools.solicitor.componentinfo.ComponentInfo;
 import com.devonfw.tools.solicitor.componentinfo.ComponentInfoAdapterException;
@@ -46,10 +45,11 @@ class ScancodeComponentInfoAdapterTest {
 
     Mockito.when(packageURLHandler.pathFor("pkg:maven/com.devonfw.tools/test-project-for-deep-license-scan@0.1.0"))
         .thenReturn("pkg/maven/com/devonfw/tools/test-project-for-deep-license-scan/0.1.0");
-    DirectUrlWebContentProvider contentProvider = new DirectUrlWebContentProvider(false);
 
-    this.fileScancodeRawComponentInfoProvider = new FileScancodeRawComponentInfoProvider(contentProvider,
-        packageURLHandler);
+    Mockito.when(packageURLHandler.pathFor("pkg:maven/com.devonfw.tools/unknown@0.1.0"))
+        .thenReturn("pkg/maven/com/devonfw/tools/unknown/0.1.0");
+
+    this.fileScancodeRawComponentInfoProvider = new FileScancodeRawComponentInfoProvider(packageURLHandler);
     this.fileScancodeRawComponentInfoProvider.setRepoBasePath("src/test/resources/scancodefileadapter/Source/repo");
 
     this.singleFileCurationProvider = new SingleFileCurationProvider(packageURLHandler);
@@ -70,7 +70,8 @@ class ScancodeComponentInfoAdapterTest {
   }
 
   /**
-   * Test the {@link ScancodeComponentInfoAdapter#getComponentInfo(String,String)} method when such package is known.
+   * Test the {@link ScancodeComponentInfoAdapter#getComponentInfo(String,String)} method when such package is not
+   * known.
    *
    * @throws ComponentInfoAdapterException if something goes wrong
    */

--- a/documentation/master-solicitor.asciidoc
+++ b/documentation/master-solicitor.asciidoc
@@ -1699,6 +1699,7 @@ Spring beans implementing this interface will be called at certain points in the
 [appendix]
 == Release Notes
 Changes in 1.21.0::
+* https://github.com/devonfw/solicitor/pull/239: Improving some internal components to reduce risk of path traversal attacks in case that these components are (re)used in some webservice implementation.
 
 Changes in 1.20.0::
 * https://github.com/devonfw/solicitor/issues/232: Set a standard for ordering LicenseNameMapping rules. Rules with an 'or-later' suffix are put before '-only' rules.


### PR DESCRIPTION
This change hardens Solicitor (and the contained components) against path traversal threads. Whilst there is only little chance to exploit an such threats within standard Solicitor (which does not have any webservice interface), the hardening might be important if any of the components are (re)used in a serverized environment