### PR TITLE
Protect MavenReader against XXE vulnerability

### DIFF
--- a/core/src/test/java/com/devonfw/tools/solicitor/reader/maven/MavenReaderTests.java
+++ b/core/src/test/java/com/devonfw/tools/solicitor/reader/maven/MavenReaderTests.java
@@ -6,12 +6,16 @@ package com.devonfw.tools.solicitor.reader.maven;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import javax.xml.bind.UnmarshalException;
 
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.devonfw.tools.solicitor.common.FileInputStreamFactory;
+import com.devonfw.tools.solicitor.common.SolicitorRuntimeException;
 import com.devonfw.tools.solicitor.model.ModelFactory;
 import com.devonfw.tools.solicitor.model.impl.ModelFactoryImpl;
 import com.devonfw.tools.solicitor.model.inventory.ApplicationComponent;
@@ -21,6 +25,9 @@ import com.devonfw.tools.solicitor.model.masterdata.UsagePattern;
 public class MavenReaderTests {
   private static final Logger LOG = LoggerFactory.getLogger(MavenReaderTests.class);
 
+  /**
+   * Tests reading a maven license file.
+   */
   @Test
   public void readFileAndCheckSize() {
 
@@ -48,6 +55,32 @@ public class MavenReaderTests {
       }
     }
     assertTrue(found);
+
+  }
+
+  /**
+   * Tests if the MavenReader rejects XML with DOCTYPE declaration which is done to prevent XXE.
+   */
+  @Test
+  public void testProtectionAgainstXxe() {
+
+    ModelFactory modelFactory = new ModelFactoryImpl();
+
+    Application application = modelFactory.newApplication("testApp", "0.0.0.TEST", "1.1.2111", "http://bla.com",
+        "Java8");
+    MavenReader mr = new MavenReader();
+    mr.setModelFactory(modelFactory);
+    mr.setInputStreamFactory(new FileInputStreamFactory());
+
+    try {
+      mr.readInventory("maven", "src/test/resources/licenses_sample_with_doctype.xml", application,
+          UsagePattern.DYNAMIC_LINKING, "maven", null);
+      fail("Expected exception was not thrown");
+    } catch (SolicitorRuntimeException e) {
+      // we check detailed message to make sure the exception is not thrown due to other reasons
+      UnmarshalException ume = (UnmarshalException) (e.getCause());
+      assertTrue(ume.getLinkedException().getMessage().contains("DOCTYPE is disallowed"));
+    }
 
   }
 }

--- a/core/src/test/resources/licenses_sample_with_doctype.xml
+++ b/core/src/test/resources/licenses_sample_with_doctype.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE licenseSummary [<!ELEMENT licenseSummary ANY >]>
+<licenseSummary>
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.poi</groupId>
+      <artifactId>poi-ooxml</artifactId>
+      <version>3.17</version>
+      <licenses>
+        <license>
+          <name>The Apache Software License, Version 2.0</name>
+          <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+        </license>
+      </licenses>
+    </dependency>
+  </dependencies>
+</licenseSummary>

--- a/documentation/master-solicitor.asciidoc
+++ b/documentation/master-solicitor.asciidoc
@@ -1699,6 +1699,7 @@ Spring beans implementing this interface will be called at certain points in the
 [appendix]
 == Release Notes
 Changes in 1.22.0::
+* https://github.com/devonfw/solicitor/pull/243: Make sure the MavenReader is protected against XXE threats. 
 
 Changes in 1.21.0::
 * https://github.com/devonfw/solicitor/pull/239: Improving some internal components to reduce risk of path traversal attacks in case that these components are (re)used in some webservice implementation.

--- a/solicitor.dict
+++ b/solicitor.dict
@@ -40,6 +40,7 @@ velo
 venv
 vm
 WTFPL
+XXE
 zA
 Zlib
 Zope


### PR DESCRIPTION
Parsing files with JAXB Unmarshaller (as used in the MavenReader) might introduce a XXE vulnerability (in case that the setup of the overall XML pluggable architecture in the java runtime is not correctly configured.) This change avoids XXE vulnerabilities in the MavenReader by using the approach as described in https://cheatsheetseries.owasp.org/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html#jaxb-unmarshaller .