### PR TITLE
Skip license matches which do not belong to the current file.

### DIFF
--- a/documentation/master-solicitor.asciidoc
+++ b/documentation/master-solicitor.asciidoc
@@ -2152,6 +2152,7 @@ Spring beans implementing this interface will be called at certain points in the
 [appendix]
 == Release Notes
 Changes in 1.29.0::
+* https://github.com/devonfw/solicitor/pull/291: Fixed a bug in the processing of ScanCode V32 files.
 * https://github.com/devonfw/solicitor/pull/290: Fixed an incorrect documentation of a rule in the user guide.
 
 Changes in 1.28.0::


### PR DESCRIPTION
The matches section of V32 scancode result files might contain matches which belong to other files than the currently processed file. We now skip these matches.