### PR TITLE
Modify the spdxIdsFromExpression method 

### DIFF
--- a/core/src/main/java/com/devonfw/tools/solicitor/componentinfo/scancode/FilteredScancodeV32ComponentInfoProvider.java
+++ b/core/src/main/java/com/devonfw/tools/solicitor/componentinfo/scancode/FilteredScancodeV32ComponentInfoProvider.java
@@ -1,8 +1,11 @@
 package com.devonfw.tools.solicitor.componentinfo.scancode;
 
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -345,7 +348,7 @@ public class FilteredScancodeV32ComponentInfoProvider implements FilteredScancod
 
   /**
    * Extracts the array of spdxIds (licenses and exceptions) from a given SPDX expression. Ignores all structural
-   * information as AND, OR, WITH.
+   * information as AND, OR, WITH. Any duplicates will be removed and the list will be sorted alphabetically.
    *
    * @param licenseExpression the spdx expression
    * @return array of found spdx ids.
@@ -360,7 +363,10 @@ public class FilteredScancodeV32ComponentInfoProvider implements FilteredScancod
     plainString = plainString.trim().replaceAll("\\s+", " ");
 
     // Split the string based on the spaces
-    return plainString.isEmpty() ? new String[0] : plainString.split(" ");
+    String[] allIds = plainString.isEmpty() ? new String[0] : plainString.split(" ");
+    // Remove duplicates and sort
+    Set<String> uniqueIds = new TreeSet<>(Arrays.asList(allIds));
+    return uniqueIds.toArray(new String[0]);
   }
 
   /**

--- a/core/src/main/java/com/devonfw/tools/solicitor/componentinfo/scancode/FilteredScancodeV32ComponentInfoProvider.java
+++ b/core/src/main/java/com/devonfw/tools/solicitor/componentinfo/scancode/FilteredScancodeV32ComponentInfoProvider.java
@@ -350,11 +350,17 @@ public class FilteredScancodeV32ComponentInfoProvider implements FilteredScancod
    * @param licenseExpression the spdx expression
    * @return array of found spdx ids.
    */
-  private String[] spdxIdsFromExpression(String licenseExpression) {
+  protected String[] spdxIdsFromExpression(String licenseExpression) {
 
+    // Remove brackets and operators with spaces
     String plainString = licenseExpression.replace("(", " ").replace(")", " ").replace(" AND ", " ")
         .replace(" OR ", " ").replace(" WITH ", " ");
-    return plainString.split("\\s+");
+
+    // Trim and consolidate spaces
+    plainString = plainString.trim().replaceAll("\\s+", " ");
+
+    // Split the string based on the spaces
+    return plainString.isEmpty() ? new String[0] : plainString.split(" ");
   }
 
   /**

--- a/core/src/test/java/com/devonfw/tools/solicitor/componentinfo/scancode/FilteredScancodeV32ComponentInfoProviderTest.java
+++ b/core/src/test/java/com/devonfw/tools/solicitor/componentinfo/scancode/FilteredScancodeV32ComponentInfoProviderTest.java
@@ -1,7 +1,6 @@
 package com.devonfw.tools.solicitor.componentinfo.scancode;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.*;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -51,7 +50,7 @@ public class FilteredScancodeV32ComponentInfoProviderTest {
 
   /**
    * Test the
-   * {@link FilteredScancodeV31ComponentInfoProvider#getComponentInfo(String,String,ScancodeRawComponentInfo,JsonNode)}
+   * {@link FilteredScancodeV31ComponentInfoProvider#getComponentInfo(String, String, ScancodeRawComponentInfo, JsonNode)}
    * method when no curations file exists
    *
    * @throws ComponentInfoAdapterException if something goes wrong
@@ -88,7 +87,7 @@ public class FilteredScancodeV32ComponentInfoProviderTest {
 
   /**
    * Test the
-   * {@link FilteredScancodeV31ComponentInfoProvider#getComponentInfo(String,String,ScancodeRawComponentInfo,JsonNode)}
+   * {@link FilteredScancodeV31ComponentInfoProvider#getComponentInfo(String, String, ScancodeRawComponentInfo, JsonNode)}
    * method when the /src directory is excluded
    *
    * @throws ComponentInfoAdapterException if something goes wrong
@@ -121,13 +120,13 @@ public class FilteredScancodeV32ComponentInfoProviderTest {
     assertEquals("This is a dummy notice file for testing. Code is under Apache-2.0.",
         scancodeComponentInfo.getComponentInfoData().getNoticeFileContent());
     assertEquals(0, scancodeComponentInfo.getComponentInfoData().getCopyrights().size()); // since the copyright is
-                                                                                          // found under
+    // found under
     // /src/../SampleClass.java1, it will be excluded
   }
 
   /**
    * Test the
-   * {@link FilteredScancodeV31ComponentInfoProvider#getComponentInfo(String,String,ScancodeRawComponentInfo,JsonNode)}
+   * {@link FilteredScancodeV31ComponentInfoProvider#getComponentInfo(String, String, ScancodeRawComponentInfo, JsonNode)}
    * method when curations exist but no paths are excluded
    *
    * @throws ComponentInfoAdapterException if something goes wrong
@@ -160,10 +159,157 @@ public class FilteredScancodeV32ComponentInfoProviderTest {
         scancodeComponentInfo.getComponentInfoData().getNoticeFileContent());
     assertEquals(1, scancodeComponentInfo.getComponentInfoData().getCopyrights().size());
     assertEquals("Copyright 2023 devonfw", scancodeComponentInfo.getComponentInfoData().getCopyrights().toArray()[0]); // The
-                                                                                                                       // copyright
+    // copyright
     // curation does not
     // apply on the
     // scancodeComponentInfo
     // object.
+  }
+
+  /**
+   * Tests for the method spdxIdsFromExpression, which extracts SPDX license IDs from a given expression.
+   */
+  @Test
+  public void testSpdxIdsFromExpression() {
+
+    // Example expression
+    String expression1 = "EPL-2.0 GPL-2.0-only BSD-3-Clause";
+    String[] result1 = filteredScancodeV32ComponentInfoProvider.spdxIdsFromExpression(expression1);
+
+    // Verify the result
+    assertArrayEquals(new String[] { "EPL-2.0", "GPL-2.0-only", "BSD-3-Clause" }, result1);
+  }
+
+  /**
+   * Tests the spdxIdsFromExpression method with an input containing operators.
+   */
+  @Test
+  public void testSpdxIdsWithOperators() {
+
+    // Input containing logical operators
+    String expression = "(EPL-2.0 AND GPL-2.0-only) OR BSD-3-Clause WITH MIT";
+
+    // Expected output
+    String[] expected = { "EPL-2.0", "GPL-2.0-only", "BSD-3-Clause", "MIT" };
+
+    // Call the method
+    String[] result = filteredScancodeV32ComponentInfoProvider.spdxIdsFromExpression(expression);
+
+    // Verify the result
+    assertArrayEquals(expected, result);
+  }
+
+  /**
+   * Tests the spdxIdsFromExpression method with an input containing parentheses.
+   */
+  @Test
+  public void testSpdxIdsWithParentheses() {
+
+    // Input containing parentheses
+    String expression = "(EPL-2.0 OR GPL-2.0-only)";
+
+    // Expected output
+    String[] expected = { "EPL-2.0", "GPL-2.0-only" };
+
+    // Call the method
+    String[] result = filteredScancodeV32ComponentInfoProvider.spdxIdsFromExpression(expression);
+
+    // Verify the result
+    assertArrayEquals(expected, result);
+  }
+
+  /**
+   * Tests the spdxIdsFromExpression method with a single license as input.
+   */
+  @Test
+  public void testSpdxIdsSingleLicense() {
+
+    // Input containing a single license
+    String expression = "MIT";
+
+    // Expected output
+    String[] expected = { "MIT" };
+
+    // Call the method
+    String[] result = filteredScancodeV32ComponentInfoProvider.spdxIdsFromExpression(expression);
+
+    // Verify the result
+    assertArrayEquals(expected, result);
+  }
+
+  /**
+   * Tests the spdxIdsFromExpression method with licenses separated by spaces.
+   */
+  @Test
+  public void testSpdxIdsWithSpaces() {
+
+    // Input containing licenses separated by spaces
+    String expression = "Apache-2.0 GPL-3.0 BSD-2-Clause";
+
+    // Expected output
+    String[] expected = { "Apache-2.0", "GPL-3.0", "BSD-2-Clause" };
+
+    // Call the method
+    String[] result = filteredScancodeV32ComponentInfoProvider.spdxIdsFromExpression(expression);
+
+    // Verify the result
+    assertArrayEquals(expected, result);
+  }
+
+  /**
+   * Tests the spdxIdsFromExpression method with input containing extra spaces.
+   */
+  @Test
+  public void testSpdxIdsWithExtraSpaces() {
+
+    // Input containing extra spaces
+    String expression = "  Apache-2.0   GPL-3.0  BSD-2-Clause   ";
+
+    // Expected output
+    String[] expected = { "Apache-2.0", "GPL-3.0", "BSD-2-Clause" };
+
+    // Call the method
+    String[] result = filteredScancodeV32ComponentInfoProvider.spdxIdsFromExpression(expression);
+
+    // Verify the result
+    assertArrayEquals(expected, result);
+  }
+
+  /**
+   * Tests the spdxIdsFromExpression method with an empty string as input.
+   */
+  @Test
+  public void testSpdxIdsEmptyString() {
+
+    // Empty input
+    String expression = "";
+
+    // Expected output
+    String[] expected = {};
+
+    // Call the method
+    String[] result = filteredScancodeV32ComponentInfoProvider.spdxIdsFromExpression(expression);
+
+    // Verify the result
+    assertArrayEquals(expected, result);
+  }
+
+  /**
+   * Tests the spdxIdsFromExpression method with complex nested operators.
+   */
+  @Test
+  public void testSpdxIdsComplexOperators() {
+
+    // Input with complex nested operators
+    String expression = "((MIT OR Apache-2.0) AND (BSD-2-Clause OR GPL-3.0))";
+
+    // Expected output
+    String[] expected = { "MIT", "Apache-2.0", "BSD-2-Clause", "GPL-3.0" };
+
+    // Call the method
+    String[] result = filteredScancodeV32ComponentInfoProvider.spdxIdsFromExpression(expression);
+
+    // Verify the result
+    assertArrayEquals(expected, result);
   }
 }

--- a/core/src/test/java/com/devonfw/tools/solicitor/componentinfo/scancode/FilteredScancodeV32ComponentInfoProviderTest.java
+++ b/core/src/test/java/com/devonfw/tools/solicitor/componentinfo/scancode/FilteredScancodeV32ComponentInfoProviderTest.java
@@ -1,6 +1,8 @@
 package com.devonfw.tools.solicitor.componentinfo.scancode;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -170,14 +172,14 @@ public class FilteredScancodeV32ComponentInfoProviderTest {
    * Tests for the method spdxIdsFromExpression, which extracts SPDX license IDs from a given expression.
    */
   @Test
-  public void testSpdxIdsFromExpression() {
+  public void testSpdxIdsFromExpressionRemoveDuplicates() {
 
     // Example expression
-    String expression1 = "EPL-2.0 GPL-2.0-only BSD-3-Clause";
-    String[] result1 = filteredScancodeV32ComponentInfoProvider.spdxIdsFromExpression(expression1);
+    String expression1 = "EPL-2.0 AND GPL-2.0-only AND BSD-3-Clause AND GPL-2.0-only";
+    String[] result1 = this.filteredScancodeV32ComponentInfoProvider.spdxIdsFromExpression(expression1);
 
     // Verify the result
-    assertArrayEquals(new String[] { "EPL-2.0", "GPL-2.0-only", "BSD-3-Clause" }, result1);
+    assertArrayEquals(new String[] { "BSD-3-Clause", "EPL-2.0", "GPL-2.0-only" }, result1);
   }
 
   /**
@@ -187,13 +189,13 @@ public class FilteredScancodeV32ComponentInfoProviderTest {
   public void testSpdxIdsWithOperators() {
 
     // Input containing logical operators
-    String expression = "(EPL-2.0 AND GPL-2.0-only) OR BSD-3-Clause WITH MIT";
+    String expression = "(EPL-2.0 AND GPL-2.0-only) OR BSD-3-Clause WITH someException";
 
     // Expected output
-    String[] expected = { "EPL-2.0", "GPL-2.0-only", "BSD-3-Clause", "MIT" };
+    String[] expected = { "BSD-3-Clause", "EPL-2.0", "GPL-2.0-only", "someException" };
 
     // Call the method
-    String[] result = filteredScancodeV32ComponentInfoProvider.spdxIdsFromExpression(expression);
+    String[] result = this.filteredScancodeV32ComponentInfoProvider.spdxIdsFromExpression(expression);
 
     // Verify the result
     assertArrayEquals(expected, result);
@@ -212,7 +214,7 @@ public class FilteredScancodeV32ComponentInfoProviderTest {
     String[] expected = { "EPL-2.0", "GPL-2.0-only" };
 
     // Call the method
-    String[] result = filteredScancodeV32ComponentInfoProvider.spdxIdsFromExpression(expression);
+    String[] result = this.filteredScancodeV32ComponentInfoProvider.spdxIdsFromExpression(expression);
 
     // Verify the result
     assertArrayEquals(expected, result);
@@ -231,7 +233,7 @@ public class FilteredScancodeV32ComponentInfoProviderTest {
     String[] expected = { "MIT" };
 
     // Call the method
-    String[] result = filteredScancodeV32ComponentInfoProvider.spdxIdsFromExpression(expression);
+    String[] result = this.filteredScancodeV32ComponentInfoProvider.spdxIdsFromExpression(expression);
 
     // Verify the result
     assertArrayEquals(expected, result);
@@ -247,10 +249,10 @@ public class FilteredScancodeV32ComponentInfoProviderTest {
     String expression = "Apache-2.0 GPL-3.0 BSD-2-Clause";
 
     // Expected output
-    String[] expected = { "Apache-2.0", "GPL-3.0", "BSD-2-Clause" };
+    String[] expected = { "Apache-2.0", "BSD-2-Clause", "GPL-3.0" };
 
     // Call the method
-    String[] result = filteredScancodeV32ComponentInfoProvider.spdxIdsFromExpression(expression);
+    String[] result = this.filteredScancodeV32ComponentInfoProvider.spdxIdsFromExpression(expression);
 
     // Verify the result
     assertArrayEquals(expected, result);
@@ -266,10 +268,10 @@ public class FilteredScancodeV32ComponentInfoProviderTest {
     String expression = "  Apache-2.0   GPL-3.0  BSD-2-Clause   ";
 
     // Expected output
-    String[] expected = { "Apache-2.0", "GPL-3.0", "BSD-2-Clause" };
+    String[] expected = { "Apache-2.0", "BSD-2-Clause", "GPL-3.0", };
 
     // Call the method
-    String[] result = filteredScancodeV32ComponentInfoProvider.spdxIdsFromExpression(expression);
+    String[] result = this.filteredScancodeV32ComponentInfoProvider.spdxIdsFromExpression(expression);
 
     // Verify the result
     assertArrayEquals(expected, result);
@@ -288,7 +290,7 @@ public class FilteredScancodeV32ComponentInfoProviderTest {
     String[] expected = {};
 
     // Call the method
-    String[] result = filteredScancodeV32ComponentInfoProvider.spdxIdsFromExpression(expression);
+    String[] result = this.filteredScancodeV32ComponentInfoProvider.spdxIdsFromExpression(expression);
 
     // Verify the result
     assertArrayEquals(expected, result);
@@ -304,10 +306,10 @@ public class FilteredScancodeV32ComponentInfoProviderTest {
     String expression = "((MIT OR Apache-2.0) AND (BSD-2-Clause OR GPL-3.0))";
 
     // Expected output
-    String[] expected = { "MIT", "Apache-2.0", "BSD-2-Clause", "GPL-3.0" };
+    String[] expected = { "Apache-2.0", "BSD-2-Clause", "GPL-3.0", "MIT" };
 
     // Call the method
-    String[] result = filteredScancodeV32ComponentInfoProvider.spdxIdsFromExpression(expression);
+    String[] result = this.filteredScancodeV32ComponentInfoProvider.spdxIdsFromExpression(expression);
 
     // Verify the result
     assertArrayEquals(expected, result);

--- a/documentation/master-solicitor.asciidoc
+++ b/documentation/master-solicitor.asciidoc
@@ -2152,6 +2152,7 @@ Spring beans implementing this interface will be called at certain points in the
 [appendix]
 == Release Notes
 Changes in 1.30.0::
+* https://github.com/devonfw/solicitor/pull/292: Improved the detection of spdxids from spdx expressions when parsing ScanCode V32 result files. Previously the result might have contained empty strings to be returned as spdxids.
 
 Changes in 1.29.0::
 * https://github.com/devonfw/solicitor/pull/291: Fixed a bug in the processing of ScanCode V32 files.

--- a/documentation/master-solicitor.asciidoc
+++ b/documentation/master-solicitor.asciidoc
@@ -2152,7 +2152,7 @@ Spring beans implementing this interface will be called at certain points in the
 [appendix]
 == Release Notes
 Changes in 1.30.0::
-* https://github.com/devonfw/solicitor/pull/292: Improved the detection of spdxids from spdx expressions when parsing ScanCode V32 result files. Previously the result might have contained empty strings to be returned as spdxids.
+* https://github.com/devonfw/solicitor/pull/292: Improved the extraction of spdxids from spdx expressions when parsing ScanCode V32 result files. Previously the result might have contained empty strings to be returned as spdxids.
 
 Changes in 1.29.0::
 * https://github.com/devonfw/solicitor/pull/291: Fixed a bug in the processing of ScanCode V32 files.


### PR DESCRIPTION
Modify the spdxIdsFromExpression method to correctly handle cases where the input contains empty or invalid SPDX identifiers, ensuring they are appropriately excluded or processed.