### PR TITLE
Feature/unsupported pkg

### DIFF
--- a/core/src/main/java/com/devonfw/tools/solicitor/common/packageurl/SolicitorPackageURLException.java
+++ b/core/src/main/java/com/devonfw/tools/solicitor/common/packageurl/SolicitorPackageURLException.java
@@ -28,5 +28,4 @@ public class SolicitorPackageURLException extends SolicitorRuntimeException {
 
     super(message, cause);
   }
-
 }

--- a/core/src/main/java/com/devonfw/tools/solicitor/common/packageurl/SolicitorPackageURLTypException.java
+++ b/core/src/main/java/com/devonfw/tools/solicitor/common/packageurl/SolicitorPackageURLTypException.java
@@ -1,12 +1,10 @@
 package com.devonfw.tools.solicitor.common.packageurl;
 
-import com.devonfw.tools.solicitor.common.SolicitorRuntimeException;
-
 /**
- * Specific kind of {@link SolicitorRuntimeException} thrown from {@link com.devonfw.tools.solicitor.common.packageurl}
- * and sub packages.
+ * Specific kind of {@link SolicitorPackageURLException} thrown from
+ * {@link com.devonfw.tools.solicitor.common.packageurl} and sub packages.
  */
-public class SolicitorPackageURLTypException extends SolicitorRuntimeException {
+public class SolicitorPackageURLTypException extends SolicitorPackageURLException {
 
   /**
    * The constructor.

--- a/core/src/main/java/com/devonfw/tools/solicitor/common/packageurl/SolicitorPackageURLTypException.java
+++ b/core/src/main/java/com/devonfw/tools/solicitor/common/packageurl/SolicitorPackageURLTypException.java
@@ -1,0 +1,31 @@
+package com.devonfw.tools.solicitor.common.packageurl;
+
+import com.devonfw.tools.solicitor.common.SolicitorRuntimeException;
+
+/**
+ * Specific kind of {@link SolicitorRuntimeException} thrown from {@link com.devonfw.tools.solicitor.common.packageurl}
+ * and sub packages.
+ */
+public class SolicitorPackageURLTypException extends SolicitorRuntimeException {
+
+  /**
+   * The constructor.
+   *
+   * @param message the message
+   */
+  public SolicitorPackageURLTypException(String message) {
+
+    super(message);
+  }
+
+  /**
+   * The constructor.
+   *
+   * @param message the message
+   * @param cause the cause
+   */
+  public SolicitorPackageURLTypException(String message, Throwable cause) {
+
+    super(message, cause);
+  }
+}

--- a/core/src/main/java/com/devonfw/tools/solicitor/common/packageurl/impl/DelegatingPackageURLHandlerImpl.java
+++ b/core/src/main/java/com/devonfw/tools/solicitor/common/packageurl/impl/DelegatingPackageURLHandlerImpl.java
@@ -8,7 +8,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import com.devonfw.tools.solicitor.common.packageurl.AllKindsPackageURLHandler;
-import com.devonfw.tools.solicitor.common.packageurl.SolicitorPackageURLException;
+import com.devonfw.tools.solicitor.common.packageurl.SolicitorPackageURLTypException;
 import com.github.packageurl.PackageURL;
 
 /**
@@ -28,7 +28,7 @@ public class DelegatingPackageURLHandlerImpl extends AbstractPackageURLHandler i
         return singleKindHandler;
       }
     }
-    throw new SolicitorPackageURLException(
+    throw new SolicitorPackageURLTypException(
         "No applicable SingleKindPackageURLHandler found for type '" + packageURL.getType() + "'");
   }
 

--- a/documentation/master-solicitor.asciidoc
+++ b/documentation/master-solicitor.asciidoc
@@ -2156,6 +2156,7 @@ Spring beans implementing this interface will be called at certain points in the
 == Release Notes
 Changes in 1.31.0::
 * https://github.com/devonfw/solicitor/issues/295: Add PackageUrlHandler for cran packages. 
+* https://github.com/devonfw/solicitor/issues/299: Add missing Exception Handling for Type-Related Errors in Package URL
 
 Changes in 1.30.0::
 * https://github.com/devonfw/solicitor/pull/292: Improved the extraction of spdxids from spdx expressions when parsing ScanCode V32 result files. Previously the result might have contained empty strings to be returned as spdxids.


### PR DESCRIPTION
SolicitorPackageURLTypException is a specific exception that inherits from SolicitorPackageURLException and is used for type-related errors in the package URL. 