### PR TITLE
Workaround in configuration to not load SPDX license from net

### DIFF
--- a/core/src/main/resources/resources/licenses.properties
+++ b/core/src/main/resources/resources/licenses.properties
@@ -1,4 +1,5 @@
 # only use builtin SPDX-ID information (not accessing web service)
+# this file is defined to work around https://github.com/spdx/Spdx-Java-Library/issues/324
 # the official (new) property (see  https://github.com/spdx/Spdx-Java-Library/issues/324)
 org.spdx.useJARLicenseInfoOnly=true
 # the deprecated but still used property (see  https://github.com/spdx/Spdx-Java-Library/issues/324)

--- a/documentation/master-solicitor.asciidoc
+++ b/documentation/master-solicitor.asciidoc
@@ -2194,6 +2194,7 @@ Spring beans implementing this interface will be called at certain points in the
 [appendix]
 == Release Notes
 Changes in 1.34.0::
+* https://github.com/devonfw/solicitor/pull/311: Workaround for issue https://github.com/spdx/Spdx-Java-Library/issues/324 which resulted in the list of SPDX-IDs being loaded via the internet even if the configuration not to do so was correctly defined.
 
 Changes in 1.33.0::
 * https://github.com/devonfw/solicitor/issues/309: Implement includeFilter/excludeFilter in all Readers. See <<Filtering of components within Readers>>.


### PR DESCRIPTION
Workaround for https://github.com/spdx/Spdx-Java-Library/issues/324