### PR TITLE
Improve diff calculation for cases of same normalizedLicense

### DIFF
--- a/core/src/main/resources/com/devonfw/tools/solicitor/sql/allden_normalizedlicenses.sql
+++ b/core/src/main/resources/com/devonfw/tools/solicitor/sql/allden_normalizedlicenses.sql
@@ -2,10 +2,11 @@
 --
 -- generate all NormalizedLicenses in denormalized form including all hierachical data  (allden -> "all denormalized")
 select
-    CONCAT(NVL(a."applicationName",'-'),NVL(ac."groupId",'-'),NVL(ac."artifactId",'-'),NVL(ac."version",'-'),NVL(l."normalizedLicense",'-')) as CORR_KEY_0,
-    CONCAT(NVL(a."applicationName",'-'),NVL(ac."groupId",'-'),NVL(ac."artifactId",'-'),NVL(l."normalizedLicense",'-')) as CORR_KEY_1,
-    CONCAT(NVL(a."applicationName",'-'),NVL(ac."groupId",'-'),NVL(ac."artifactId",'-'),NVL(ac."version",'-')) as CORR_KEY_2,
-    CONCAT(NVL(a."applicationName",'-'),NVL(ac."groupId",'-'),NVL(ac."artifactId",'-')) as CORR_KEY_3,
+    CONCAT(NVL(a."applicationName",'-'),NVL(ac."groupId",'-'),NVL(ac."artifactId",'-'),NVL(ac."version",'-'),NVL(l."normalizedLicense",'-'),NVL(l."declaredLicense",'-')) as CORR_KEY_0,
+    CONCAT(NVL(a."applicationName",'-'),NVL(ac."groupId",'-'),NVL(ac."artifactId",'-'),NVL(ac."version",'-'),NVL(l."normalizedLicense",'-')) as CORR_KEY_1,
+    CONCAT(NVL(a."applicationName",'-'),NVL(ac."groupId",'-'),NVL(ac."artifactId",'-'),NVL(l."normalizedLicense",'-')) as CORR_KEY_2,
+    CONCAT(NVL(a."applicationName",'-'),NVL(ac."groupId",'-'),NVL(ac."artifactId",'-'),NVL(ac."version",'-')) as CORR_KEY_3,
+    CONCAT(NVL(a."applicationName",'-'),NVL(ac."groupId",'-'),NVL(ac."artifactId",'-')) as CORR_KEY_4,
 	e.*,
 	a.*,
 	ac.*,

--- a/documentation/master-solicitor.asciidoc
+++ b/documentation/master-solicitor.asciidoc
@@ -2194,6 +2194,7 @@ Spring beans implementing this interface will be called at certain points in the
 [appendix]
 == Release Notes
 Changes in 1.35.0::
+* https://github.com/devonfw/solicitor/pull/313: Added an additional correlation key to ensure diff calculation works even for multiple identical normalizedLicenses (e.g. unknown) and different declaredLicenses
 
 Changes in 1.34.0::
 * https://github.com/devonfw/solicitor/pull/311: Workaround for issue https://github.com/spdx/Spdx-Java-Library/issues/324 which resulted in the list of SPDX-IDs being loaded via the internet even if the configuration not to do so was correctly defined.


### PR DESCRIPTION
Added an additional correlation key to ensure diff calculation works even for multiple identical normalizedLicenses (unknown) and different declaredLicenses