### PR TITLE
change origin.yaml to package.yaml

### DIFF
--- a/core/src/main/java/com/devonfw/tools/solicitor/componentinfo/scancode/FileScancodeRawComponentInfoProvider.java
+++ b/core/src/main/java/com/devonfw/tools/solicitor/componentinfo/scancode/FileScancodeRawComponentInfoProvider.java
@@ -151,7 +151,7 @@ public class FileScancodeRawComponentInfoProvider implements ScancodeRawComponen
   }
 
   /**
-   * Adds the data about the origin of the package which is (optionally) contained in file "origin.yaml"
+   * Adds the data about the origin of the package which is (optionally) contained in file "package.yaml"
    *
    * @param packageUrl the identifier of the package
    * @param componentScancodeInfos the componentScancodeInfos to add the origin data to
@@ -161,7 +161,7 @@ public class FileScancodeRawComponentInfoProvider implements ScancodeRawComponen
       throws ComponentInfoAdapterException {
 
     String packagePathPart = this.packageURLHandler.pathFor(packageUrl);
-    String path = IOHelper.secureFilePath(this.repoBasePath, packagePathPart, "origin.yaml");
+    String path = IOHelper.secureFilePath(this.repoBasePath, packagePathPart, "package.yaml");
 
     File originFile = new File(path);
     if (!originFile.exists()) {
@@ -189,7 +189,7 @@ public class FileScancodeRawComponentInfoProvider implements ScancodeRawComponen
       componentScancodeInfos.packageDownloadUrl = packageDownloadUrl;
 
     } catch (IOException e) {
-      throw new ComponentInfoAdapterException("Could not read origin.yaml", e);
+      throw new ComponentInfoAdapterException("Could not read package.yaml", e);
     }
   }
 

--- a/core/src/main/resources/com/devonfw/tools/solicitor/templates/ScancodeScript.vm
+++ b/core/src/main/resources/com/devonfw/tools/solicitor/templates/ScancodeScript.vm
@@ -31,13 +31,14 @@ echo "These artifacts need to be downloaded manually:" > need-to-retrieve-manual
 			rm sources.failed
 			rm -r sources
 			rm sources.jar
-			if [ ! -f origin.yaml ] 
+			if [ ! -f package.yaml ]
 			then
-				echo "# This file contains metadata about the orgin of the package and the sources." > origin.yaml
-				echo "# This file was automatically created but might manually be edited if the contained data is not correct" >> origin.yaml
-				echo "sourceDownloadUrl: $purlhandler.sourceDownloadUrlFor($artifact.packageUrl)" >> origin.yaml
-				echo "packageDownloadUrl: $purlhandler.packageDownloadUrlFor($artifact.packageUrl)" >> origin.yaml
-				echo "# note: to add comments: write them here and remove the hash at the beginning of the line" >> origin.yaml
+				echo "# This file contains metadata about the orgin of the package and the sources." > package.yaml
+				echo "# This file was automatically created but might manually be edited if the contained data is not correct" >> package.yaml
+				echo "sourceDownloadUrl: $purlhandler.sourceDownloadUrlFor($artifact.packageUrl)" >> package.yaml
+				echo "packageDownloadUrl: $purlhandler.packageDownloadUrlFor($artifact.packageUrl)" >> package.yaml
+				echo "packageUrl: $artifact.packageUrl" >> package.yaml
+				echo "# note: to add comments: write them here and remove the hash at the beginning of the line" >> package.yaml
 			fi
 			curl -# $purlhandler.sourceDownloadUrlFor($artifact.packageUrl) -o sources.$purlhandler.sourceArchiveSuffixFor($artifact.packageUrl)
 			#if ( $purlhandler.sourceArchiveSuffixFor($artifact.packageUrl) == "jar" )

--- a/documentation/master-solicitor.asciidoc
+++ b/documentation/master-solicitor.asciidoc
@@ -1726,7 +1726,7 @@ Results are stored in subdirectory `Source` of the directory `output` and is org
 ===== Origin file
 The Scancode integration scripts try to download ApplicationComponent sources from default URLs derived from the PackageUrl (e.g. Maven Central). In cases where the sources are not available at these locations, the download will fail (and the subsequent source scan will be skipped). In this case it is possible to manually download the sources from some other location and store it in the directory structure. Restarting the Scancode integration script might then perform the source scan.
 
-To be able to document the (non default) origin of the ApplicationComponent sources a file `origin.yaml` is created in the components directory in the file system. If the failed source download has been performed manually it is possible to edit this file and correct the data given in this file.
+To be able to document the (non default) origin of the ApplicationComponent sources a file `package.yaml` is created in the components directory in the file system. If the failed source download has been performed manually it is possible to edit this file and correct the data given in this file.
 
 [source,yaml]
 ----
@@ -1739,7 +1739,7 @@ packageDownloadUrl: https://url/pointing/to/the/binary/archive.jar <2>
 <1> URL for downloading the sources - will be available as property `ApplicationComponent.sourceDownloadUrl` in the Solicitor data model.
 <2> URL for downloading the binaries - will be available as property `ApplicationComponent.packageDownloadUrl` in the Solicitor data model.
 
-The content of the file `origin.yaml` currently just affects the above given two properties, it does not affect the downloading of sources by the scripts.
+The content of the file `package.yaml` currently just affects the above given two properties, it does not affect the downloading of sources by the scripts.
 
 
 ==== Solicitor 2nd run
@@ -1751,7 +1751,7 @@ _Solicitor_ will try to look up ScanCode information from the directory tree in 
 * Copyrights are taken from ScanCode results
 * Info on NOTICE file is taken from the ScanCode results
 * If the ScanCode results contain information about project URLs this is stored as `sourceRepoUrl` and/or `ossHomepage`
-* `sourceDownloadUrl`  and `packageDownloadUrl` are set to the values given in file `origin.yaml`
+* `sourceDownloadUrl`  and `packageDownloadUrl` are set to the values given in file `package.yaml`
 
 ==== Output
 Main target of the additional information obtained from ScanCode is currently the new report `Attributions_PROJECTNAME.html` which lists
@@ -2318,7 +2318,7 @@ Changes in 1.11.0::
 * https://github.com/devonfw/solicitor/issues/168: Fixed NullPointerException for blank license in License URL Guessing.
 
 Changes in 1.10.0::
-* https://github.com/devonfw/solicitor/issues/175: Introduce new properties `packageDownloadUrl` and `sourceDownloadUrl` in `ApplicationComponent`. Process file `origin.yaml` within <<Experimental Scancode Integration>> to be able to set these properties to non default values.
+* https://github.com/devonfw/solicitor/issues/175: Introduce new properties `packageDownloadUrl` and `sourceDownloadUrl` in `ApplicationComponent`. Process file `package.yaml` within <<Experimental Scancode Integration>> to be able to set these properties to non default values.
 * https://github.com/devonfw/solicitor/issues/177: Contents of local resources (`file:`) are no longer cached in FilesystemCachingContentProvider.
 
 Changes in 1.9.0::


### PR DESCRIPTION
Rename **origin.yaml** to **package.yaml**:
- All files named origin.yaml are renamed to package.yaml during processing.
- Add **packageUrl** Field:
 The **packageUrl** field is added to the package.yaml file.